### PR TITLE
security hardening + test suite + post-1.0 roadmap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -884,6 +884,146 @@ Integrations: `media_controls`, `notifications`, `global_shortcuts` — each lis
 
 ---
 
+## 12a. Future Roadmap
+
+Post-1.0 feature roadmap. Ordered roughly by user value × implementation cost.
+All features must preserve the single-source-of-truth invariant: `PlayerState`
+in Rust remains the only authoritative playback state; new surfaces subscribe
+to the existing event bus rather than polling the YTM WebView independently.
+
+### Tier 1 — Requested (commit)
+
+#### Login Optimization (M)
+
+The current flow (§11) requires the user to click "Show YouTube Music",
+log in inside the raw YTM window, then click "Done" to tell the app they're
+finished. That manual handshake is the single roughest edge on first run and
+on cookie expiry.
+
+- **Auto-detect login:** Poll `document.cookie` / check for the `SAPISID`
+  cookie on the YTM WebView from Rust. As soon as the authenticated cookie
+  set appears, fire a `auth:logged_in` event on the bus and auto-hide the
+  YTM window. The "Done" button disappears entirely.
+- **Direct navigation:** Open the hidden window straight to
+  `https://accounts.google.com/ServiceLogin?service=youtube&continue=https://music.youtube.com`
+  instead of `music.youtube.com` + manual click-through. Saves 2–3 clicks.
+- **Session restore:** On launch, probe YTM headless first. Only surface the
+  login UI if the probe returns unauthenticated. Today every launch shows
+  the login page briefly until state hydrates — this removes that flicker.
+- **Graceful re-auth:** When cookies expire mid-session, surface a toast
+  ("Your YouTube Music session expired — sign in to continue") that opens
+  the YTM window inline instead of bouncing the user back to the full login
+  page and losing scroll position / queue context.
+- **Guest / browse-only mode:** Allow browsing public YTM content (search,
+  explore) without logging in. Library / playback stays gated but the app
+  becomes usable immediately on first launch for the "just trying it" path.
+- **Secure storage hardening:** Today auth is persisted via
+  `tauri-plugin-store`. Migrate the sensitive cookie blob to the macOS
+  Keychain (`security-framework` crate) so it's not plaintext on disk.
+
+Success metric: first-launch time from app open to "I can play a song"
+drops below 15 seconds for a user with an existing Google session in
+Safari/Chrome.
+
+#### Themes (L)
+
+Pluggable visual themes on top of the existing design tokens (§9). Ship with
+Light, Dark (default), and a "Dynamic" mode that extracts accent from current
+artwork.
+
+- **Token layer:** All color usage already routes through CSS custom
+  properties in §9. A theme is just a `:root[data-theme="…"]` override block.
+- **Storage:** `app_settings.theme: "light" | "dark" | "dynamic" | "<custom>"`
+  persisted via `tauri-plugin-store`. Settings page exposes a picker.
+- **Dynamic mode:** Reuse the album-art color extraction planned for §12
+  Phase 3; apply extracted hue to `--color-accent` on track change with a
+  300ms crossfade.
+- **Custom themes:** User-authored JSON in `~/Library/Application Support/VibeYTM/themes/*.json`.
+  A theme declares only token overrides — never arbitrary CSS — so the
+  attack surface stays zero.
+- **System sync:** `prefers-color-scheme` listener toggles between the user's
+  chosen light and dark themes when "System" is selected.
+
+#### Focus Mode (M)
+
+A Pomodoro-style countdown timer embedded in the NowPlaying page, inspired by
+the Focus app on macOS. Used for study / deep-work sessions.
+
+- **UI:** Circular progress ring overlaid on the album art on NowPlaying.
+  Presets: 25/50/90 min, plus custom. Start/pause/reset controls under the
+  playback transport.
+- **Behavior:**
+  - Countdown runs in Rust (`tokio::time::interval`) so the UI can close
+    without losing state.
+  - On expiry: pause playback, show a non-intrusive notification, optionally
+    play a soft chime (separate `<audio>` element in the React window — not
+    routed through the YTM engine).
+  - Optional "strict mode": disables tab switching (sidebar click handlers
+    gated) and mutes notifications until the timer ends.
+- **State:** New `FocusSession { started_at, duration_ms, status }` in Rust,
+  emitted on the event bus as `focus:tick` / `focus:complete`. Does not touch
+  `PlayerState`.
+- **Stats:** Persist completed sessions to SQLite for a future "focus history"
+  view. Defer the history UI until someone asks.
+
+#### Lyrics (M)
+
+Synced lyrics display on the NowPlaying page and as an optional overlay on
+the PlayerBar.
+
+- **Source order:**
+  1. YTM's own lyrics endpoint (`browse` with lyrics tab param) — already
+     accessible via `ytm_api`, no new auth.
+  2. LRCLIB (free, open, synced `.lrc` format) as fallback.
+  3. Musixmatch / Genius — deferred; licensing friction.
+- **Format:** Normalize to `Vec<LyricLine { time_ms, text }>`; if the source
+  is unsynced, fall back to scrolling plain text.
+- **Sync:** The existing 250ms `player:tick` event drives the active-line
+  highlight. No new polling.
+- **Cache:** Reuse the disk cache (§ `cache` module) keyed by `video_id`, 30-day
+  TTL. Image cache and lyric cache share eviction logic.
+- **Translate:** Optional "show translation" toggle (English → user locale)
+  via a local on-device model is a deferred stretch goal.
+
+### Tier 2 — High ROI follow-ups
+
+Researched against th-ch/youtube-music, Cider, Feishin, Spotify, and Apple
+Music. All are clean fits for the wrapper architecture (we don't own the
+catalog or audio engine, so features that require either are Tier 3).
+
+| # | Feature | Difficulty | Value | Notes |
+|---|---------|------------|-------|-------|
+| 1 | Discord Rich Presence | L | High | `discord-rich-presence` Rust crate, subscribe to `player:track` events. Toggle in settings. |
+| 2 | Last.fm / ListenBrainz scrobbling | L | High | HTTP POST on track-change; OAuth handled in a Tauri window. Core power-user feature. |
+| 3 | macOS Now Playing / media keys | M | Critical | Already planned Phase 4. Bumped to roadmap because without it the app doesn't feel native. MediaRemote framework via `objc2`. |
+| 4 | SponsorBlock for music | M | High | Hidden-WebView JS injection seeks past non-music segments. Most-praised th-ch/youtube-music plugin. Requires content warning in settings. |
+| 5 | Mini player window | L | High | Second Tauri window, subset of React UI, reuses existing event bus. Always-on-top floating player. |
+| 6 | Customizable keyboard shortcuts | L | Medium | `tauri-plugin-global-shortcut` + settings UI. Basic shortcuts planned Phase 3; customization is the delta. |
+| 7 | Playback history (local) | L | Medium | `rusqlite`, SQLite in app data dir. Track plays independently of YTM's own history. Enables the Focus stats view and future smart queue. |
+| 8 | Sleep timer | L | Medium | Sibling of Focus Mode — pause-after-N-minutes with optional fade-out. Shares timer infrastructure. |
+| 9 | Play on launch / resume | L | Medium | Restore queue + position on app start. Requires persisting `PlayerState` snapshot on graceful shutdown. |
+| 10 | Cross-fade between tracks | H | Medium | Deferred: we don't own the audio engine. Would require dual hidden WebViews or WebAudio interception. Prototype only. |
+
+### Tier 3 — Deferred / uncertain
+
+- **Audio EQ + loudness normalization:** WebAudio injection into hidden YTM
+  view; YTM actively resists tampering. High risk, high maintenance.
+- **Offline download cache (yt-dlp sidecar):** Legally gray, platform TOS
+  friction. Reconsider only if VibeYTM goes fully self-hosted.
+- **Plugin system:** Only worth building once ≥3 real integrations exist and
+  are stable. Premature abstraction otherwise.
+- **Lyric translation (on-device):** Waits for a small enough model to ship
+  without bloating the DMG past 150 MB.
+
+### Sequencing principle
+
+Every roadmap item must either (a) subscribe to the existing event bus, or
+(b) introduce new Rust state that is orthogonal to `PlayerState`. No feature
+is allowed to poll the YTM WebView directly — the bridge is the sole reader.
+This keeps the architecture invariants from §1 intact as the surface grows.
+
+---
+
 ## 13. Debuggability
 
 ### Structured Logging

--- a/src-tauri/src/cache/mod.rs
+++ b/src-tauri/src/cache/mod.rs
@@ -261,3 +261,133 @@ fn touch(path: &Path) -> Result<()> {
     f.set_times(times)
         .map_err(|e| anyhow!("set_times {}: {e}", path.display()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Build an isolated temp dir for each test. We don't pull in `tempfile`
+    /// to keep dev-deps minimal — nanos + a monotonic counter is collision-free
+    /// for a single test binary.
+    fn test_root() -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("vibeytm-cache-test-{}-{}", nanos, n));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn make_cache() -> (Cache, PathBuf) {
+        let root = test_root();
+        let cache = Cache::new(root.clone()).expect("cache::new");
+        (cache, root)
+    }
+
+    #[test]
+    fn image_path_is_deterministic_for_same_url() {
+        let (cache, _root) = make_cache();
+        let (p1, h1) = cache.image_path("https://i.ytimg.com/vi/abc/hq.jpg");
+        let (p2, h2) = cache.image_path("https://i.ytimg.com/vi/abc/hq.jpg");
+        assert_eq!(p1, p2);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn image_path_differs_for_different_urls() {
+        let (cache, _root) = make_cache();
+        let (p1, h1) = cache.image_path("https://i.ytimg.com/vi/abc/hq.jpg");
+        let (p2, h2) = cache.image_path("https://i.ytimg.com/vi/xyz/hq.jpg");
+        assert_ne!(p1, p2);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn ttl_jitter_is_within_window() {
+        // Jitter must always fall in [BASE_TTL, BASE_TTL + MAX_JITTER).
+        let h = [0u8; 32];
+        let t = ttl_for(&h);
+        assert!(t >= BASE_TTL_SECS);
+        assert!(t < BASE_TTL_SECS + MAX_JITTER_SECS);
+
+        let h2 = [0xff, 0xff];
+        let t2 = ttl_for(&h2);
+        assert!(t2 >= BASE_TTL_SECS);
+        assert!(t2 < BASE_TTL_SECS + MAX_JITTER_SECS);
+    }
+
+    #[test]
+    fn ttl_jitter_is_stable_for_same_hash() {
+        // Must be deterministic so an entry doesn't flip to expired mid-run.
+        let h = [0x42, 0x13, 0x37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(ttl_for(&h), ttl_for(&h));
+    }
+
+    #[test]
+    fn track_roundtrip() {
+        let (cache, _root) = make_cache();
+        cache.put_track("dQw4w9WgXcQ", r#"{"title":"x"}"#).unwrap();
+        let got = cache.get_track("dQw4w9WgXcQ").unwrap();
+        assert_eq!(got, Some(r#"{"title":"x"}"#.to_string()));
+    }
+
+    #[test]
+    fn track_missing_returns_none() {
+        let (cache, _root) = make_cache();
+        assert_eq!(cache.get_track("nope").unwrap(), None);
+    }
+
+    #[test]
+    fn put_get_track_duration_roundtrip() {
+        let (cache, _root) = make_cache();
+        cache.put_track_duration("abc123", 214.5);
+        assert_eq!(cache.get_track_duration("abc123"), Some(214.5));
+    }
+
+    #[test]
+    fn put_track_duration_rejects_empty_id_and_non_positive() {
+        let (cache, _root) = make_cache();
+        cache.put_track_duration("", 10.0);
+        cache.put_track_duration("abc", 0.0);
+        cache.put_track_duration("abc", -5.0);
+        assert_eq!(cache.get_track_duration(""), None);
+        assert_eq!(cache.get_track_duration("abc"), None);
+    }
+
+    #[test]
+    fn stats_reflect_writes() {
+        let (cache, _root) = make_cache();
+        cache.put_track("a", r#"{"x":1}"#).unwrap();
+        cache.put_track("b", r#"{"y":2}"#).unwrap();
+        let stats = cache.stats().unwrap();
+        assert_eq!(stats.track_count, 2);
+        assert!(stats.track_bytes > 0);
+        assert_eq!(stats.image_count, 0);
+        assert_eq!(stats.max_bytes, MAX_IMAGE_CACHE_BYTES);
+    }
+
+    #[tokio::test]
+    async fn clear_removes_tracks_and_returns_freed_bytes() {
+        let (cache, _root) = make_cache();
+        cache.put_track("a", r#"{"x":1}"#).unwrap();
+        cache.put_track("b", r#"{"y":2}"#).unwrap();
+        let before = cache.stats().unwrap().total_bytes;
+        let freed = cache.clear().await.unwrap();
+        assert_eq!(freed, before);
+        let after = cache.stats().unwrap();
+        assert_eq!(after.track_count, 0);
+        assert_eq!(after.total_bytes, 0);
+    }
+
+    #[test]
+    fn is_expired_true_for_missing_file() {
+        let missing = std::env::temp_dir().join("vibeytm-definitely-missing-xyz");
+        let _ = fs::remove_file(&missing);
+        assert!(Cache::is_expired(&missing, &[0u8; 32]));
+    }
+}

--- a/src-tauri/src/commands/cache.rs
+++ b/src-tauri/src/commands/cache.rs
@@ -4,16 +4,84 @@ use tauri::State;
 
 use crate::cache::{Cache, CacheStats};
 
+/// Hostnames permitted for remote image fetches. Anything else is rejected
+/// to prevent SSRF via attacker-controlled URLs flowing through the
+/// `cache_fetch_image` IPC command.
+const ALLOWED_IMAGE_HOST_SUFFIXES: &[&str] = &[
+    "ytimg.com",
+    "youtube.com",
+    "googleusercontent.com",
+    "ggpht.com",
+];
+
+fn validate_image_url(url: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("invalid url: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err("image url must use https".into());
+    }
+    let host = parsed.host_str().ok_or("image url must have a host")?;
+    let host_lower = host.to_ascii_lowercase();
+    let allowed = ALLOWED_IMAGE_HOST_SUFFIXES.iter().any(|suffix| {
+        host_lower == *suffix || host_lower.ends_with(&format!(".{suffix}"))
+    });
+    if !allowed {
+        return Err(format!("image host not allowed: {host}"));
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn cache_fetch_image(
     cache: State<'_, Cache>,
     url: String,
 ) -> Result<String, String> {
+    validate_image_url(&url)?;
     let path = cache
         .get_or_fetch_image(&url)
         .await
         .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_image_url;
+
+    #[test]
+    fn accepts_ytimg() {
+        assert!(validate_image_url("https://i.ytimg.com/vi/abc/hqdefault.jpg").is_ok());
+    }
+
+    #[test]
+    fn accepts_googleusercontent() {
+        assert!(validate_image_url("https://lh3.googleusercontent.com/abc=s512").is_ok());
+    }
+
+    #[test]
+    fn rejects_http() {
+        assert!(validate_image_url("http://i.ytimg.com/vi/abc.jpg").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_host() {
+        assert!(validate_image_url("https://evil.example.com/pwn.jpg").is_err());
+    }
+
+    #[test]
+    fn rejects_host_suffix_trick() {
+        // `evilytimg.com` must not match because of the `.` boundary check.
+        assert!(validate_image_url("https://evilytimg.com/x.jpg").is_err());
+    }
+
+    #[test]
+    fn rejects_file_scheme() {
+        assert!(validate_image_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(validate_image_url("not a url").is_err());
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/webview_bridge/mod.rs
+++ b/src-tauri/src/webview_bridge/mod.rs
@@ -8,6 +8,26 @@ pub fn get_ytm_window(app: &AppHandle) -> Option<WebviewWindow> {
     app.get_webview_window("ytm")
 }
 
+/// Validate that a string contains only characters safe for YTM IDs
+/// (alphanumerics, `_`, `-`) and does not exceed `max_len`.
+///
+/// YouTube video IDs are always 11 chars of `[A-Za-z0-9_-]`; playlist IDs
+/// share the same alphabet but can be longer. Enforcing this before any
+/// `format!`-based JS interpolation eliminates the injection vector in
+/// `navigate_to_track` / `navigate_to_track_with_playlist`.
+fn validate_ytm_id(id: &str, max_len: usize, field: &str) -> Result<(), String> {
+    if id.is_empty() || id.len() > max_len {
+        return Err(format!("invalid {field}: length out of range"));
+    }
+    if !id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        return Err(format!("invalid {field}: illegal characters"));
+    }
+    Ok(())
+}
+
 /// Manually inject the player bridge (for re-injection/debugging).
 pub fn inject_bridge(window: &WebviewWindow) -> Result<(), String> {
     tracing::info!("manually re-injecting player bridge");
@@ -56,6 +76,7 @@ pub fn exec_playback_command_with_args(
 /// page reload) while still updating the YTM DOM properly.
 pub fn navigate_to_track(window: &WebviewWindow, video_id: &str) -> Result<(), String> {
     tracing::info!(video_id, "navigate_to_track");
+    validate_ytm_id(video_id, 20, "video_id")?;
     let js = format!(
         r#"(function() {{
             var vid = '{vid}';
@@ -83,6 +104,8 @@ pub fn navigate_to_track_with_playlist(
     playlist_id: &str,
 ) -> Result<(), String> {
     tracing::info!(video_id, playlist_id, "navigate_to_track_with_playlist");
+    validate_ytm_id(video_id, 20, "video_id")?;
+    validate_ytm_id(playlist_id, 100, "playlist_id")?;
     let js = format!(
         r#"(function() {{
             var vid = '{vid}';
@@ -102,4 +125,40 @@ pub fn navigate_to_track_with_playlist(
         list = playlist_id
     );
     window.eval(&js).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_ytm_id;
+
+    #[test]
+    fn accepts_valid_video_id() {
+        assert!(validate_ytm_id("dQw4w9WgXcQ", 20, "video_id").is_ok());
+    }
+
+    #[test]
+    fn accepts_valid_playlist_id() {
+        assert!(validate_ytm_id("PL-abc_123XYZ", 100, "playlist_id").is_ok());
+    }
+
+    #[test]
+    fn rejects_single_quote_injection() {
+        assert!(validate_ytm_id("a';alert(1);//", 20, "video_id").is_err());
+    }
+
+    #[test]
+    fn rejects_angle_brackets() {
+        assert!(validate_ytm_id("<script>", 20, "video_id").is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_ytm_id("", 20, "video_id").is_err());
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let long = "a".repeat(21);
+        assert!(validate_ytm_id(&long, 20, "video_id").is_err());
+    }
 }

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -1421,3 +1421,196 @@ fn parse_playlist_from_two_row(two_row: &Value) -> Option<PlaylistSummary> {
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- parse_duration_text ----------------------------------------------
+
+    #[test]
+    fn parse_duration_text_mm_ss() {
+        assert_eq!(parse_duration_text("3:45"), 225.0);
+    }
+
+    #[test]
+    fn parse_duration_text_hh_mm_ss() {
+        assert_eq!(parse_duration_text("1:02:03"), 3723.0);
+    }
+
+    #[test]
+    fn parse_duration_text_pads_single_digit_seconds() {
+        assert_eq!(parse_duration_text("0:07"), 7.0);
+    }
+
+    #[test]
+    fn parse_duration_text_handles_leading_whitespace() {
+        assert_eq!(parse_duration_text("  4:20  "), 260.0);
+    }
+
+    #[test]
+    fn parse_duration_text_returns_zero_for_malformed() {
+        assert_eq!(parse_duration_text(""), 0.0);
+        assert_eq!(parse_duration_text("abc"), 0.0);
+        assert_eq!(parse_duration_text("1:2:3:4"), 0.0); // too many parts
+    }
+
+    // ---- runs_text --------------------------------------------------------
+
+    #[test]
+    fn runs_text_concatenates_text_fields() {
+        let v = json!([
+            { "text": "Hello" },
+            { "text": ", " },
+            { "text": "world" },
+        ]);
+        assert_eq!(runs_text(&v), "Hello, world");
+    }
+
+    #[test]
+    fn runs_text_skips_missing_text() {
+        let v = json!([
+            { "text": "A" },
+            { "notText": "B" },
+            { "text": "C" },
+        ]);
+        assert_eq!(runs_text(&v), "AC");
+    }
+
+    #[test]
+    fn runs_text_returns_empty_for_non_array() {
+        assert_eq!(runs_text(&json!("not an array")), "");
+        assert_eq!(runs_text(&json!(null)), "");
+    }
+
+    // ---- best_thumbnail ---------------------------------------------------
+
+    #[test]
+    fn best_thumbnail_picks_last_entry() {
+        // YTM returns thumbnails smallest-first, so the last one is highest-res.
+        let v = json!([
+            { "url": "https://i.ytimg.com/vi/x/default.jpg", "width": 120 },
+            { "url": "https://i.ytimg.com/vi/x/mqdefault.jpg", "width": 320 },
+            { "url": "https://i.ytimg.com/vi/x/hqdefault.jpg", "width": 480 },
+        ]);
+        assert_eq!(best_thumbnail(&v), "https://i.ytimg.com/vi/x/hqdefault.jpg");
+    }
+
+    #[test]
+    fn best_thumbnail_returns_empty_for_missing() {
+        assert_eq!(best_thumbnail(&json!([])), "");
+        assert_eq!(best_thumbnail(&json!(null)), "");
+    }
+
+    // ---- extract_video_id -------------------------------------------------
+
+    #[test]
+    fn extract_video_id_from_playlist_item_data() {
+        let renderer = json!({
+            "playlistItemData": { "videoId": "dQw4w9WgXcQ" }
+        });
+        assert_eq!(extract_video_id(&renderer), "dQw4w9WgXcQ");
+    }
+
+    #[test]
+    fn extract_video_id_from_overlay_play_button() {
+        let renderer = json!({
+            "overlay": {
+                "musicItemThumbnailOverlayRenderer": {
+                    "content": {
+                        "musicPlayButtonRenderer": {
+                            "playNavigationEndpoint": {
+                                "watchEndpoint": { "videoId": "overlay_vid" }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(extract_video_id(&renderer), "overlay_vid");
+    }
+
+    #[test]
+    fn extract_video_id_from_flex_column_runs() {
+        let renderer = json!({
+            "flexColumns": [{
+                "musicResponsiveListItemFlexColumnRenderer": {
+                    "text": {
+                        "runs": [{
+                            "text": "Song Name",
+                            "navigationEndpoint": {
+                                "watchEndpoint": { "videoId": "flex_vid" }
+                            }
+                        }]
+                    }
+                }
+            }]
+        });
+        assert_eq!(extract_video_id(&renderer), "flex_vid");
+    }
+
+    #[test]
+    fn extract_video_id_returns_empty_when_absent() {
+        assert_eq!(extract_video_id(&json!({})), "");
+    }
+
+    #[test]
+    fn extract_video_id_prefers_playlist_item_data() {
+        // When multiple paths are present, the preferred source wins.
+        let renderer = json!({
+            "playlistItemData": { "videoId": "PRIMARY" },
+            "overlay": {
+                "musicItemThumbnailOverlayRenderer": {
+                    "content": {
+                        "musicPlayButtonRenderer": {
+                            "playNavigationEndpoint": {
+                                "watchEndpoint": { "videoId": "SECONDARY" }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(extract_video_id(&renderer), "PRIMARY");
+    }
+
+    // ---- parse_search_suggestions ----------------------------------------
+
+    #[test]
+    fn parse_search_suggestions_extracts_runs_text() {
+        // Based on the actual YTM suggestions response shape.
+        let data = json!({
+            "contents": [{
+                "searchSuggestionsSectionRenderer": {
+                    "contents": [
+                        {
+                            "searchSuggestionRenderer": {
+                                "suggestion": {
+                                    "runs": [
+                                        { "text": "rick " },
+                                        { "text": "astley" }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "searchSuggestionRenderer": {
+                                "suggestion": {
+                                    "runs": [{ "text": "rickroll" }]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }]
+        });
+        let suggestions = parse_search_suggestions(&data);
+        assert_eq!(suggestions, vec!["rick astley", "rickroll"]);
+    }
+
+    #[test]
+    fn parse_search_suggestions_empty_for_bad_shape() {
+        assert!(parse_search_suggestions(&json!({})).is_empty());
+        assert!(parse_search_suggestions(&json!(null)).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- **Security**: fix 2 HIGH-severity issues found in an internal review — JS injection in `webview_bridge::navigate_to_track{,_with_playlist}` and SSRF in `commands::cache::cache_fetch_image`.
- **Tests**: +28 unit tests (41 passing total) covering the cache module, YTM API parsers, and both new validators. No new dev-deps.
- **Docs**: DESIGN.md §12a post-1.0 roadmap (Login Optimization, Themes, Focus Mode, Lyrics + Tier 2/3 features).

## Security fixes

### 1. JS injection — `webview_bridge/mod.rs`

`navigate_to_track` and `navigate_to_track_with_playlist` interpolated `video_id` / `playlist_id` directly into `format!`-based JS eval strings with single-quote delimiters and no escaping. An attacker-controlled ID containing `'` would break out of the string literal and execute arbitrary JS inside the YTM webview.

**Fix**: new `validate_ytm_id()` helper enforcing `[A-Za-z0-9_-]` alphabet + length caps (video=20, playlist=100). Called before any `format!` interpolation. Real YTM IDs (video=11 chars, playlist ≤ ~36) pass comfortably; injection payloads are rejected.

### 2. SSRF — `commands/cache.rs`

`cache_fetch_image` accepted an arbitrary `url: String` from the frontend and issued an unconditional `reqwest::get(url)` — no scheme check, no host restriction.

**Fix**: new `validate_image_url()` enforcing `https://` scheme and a hostname suffix allowlist (`ytimg.com`, `youtube.com`, `googleusercontent.com`, `ggpht.com`). Suffix match uses a `.` boundary so `evilytimg.com` does **not** match.

## Tests

| Suite | Tests | What it covers |
|---|---|---|
| `cache::tests` | 11 | path determinism, TTL jitter window/stability, track roundtrip, duration helpers edge cases, stats, async `clear()`, `is_expired` missing |
| `commands::cache::tests` | 7 | SSRF allowlist — allowed hosts, http, unknown hosts, suffix trick, `file://`, garbage |
| `webview_bridge::tests` | 6 | injection alphabet — happy path, `';alert(1);//`, `<script>`, empty, oversize |
| `ytm_api::tests` | 17 | `parse_duration_text`, `runs_text`, `best_thumbnail`, `extract_video_id` (all 3 known YTM API paths + priority), `parse_search_suggestions` |
| **Total** | **41** | `cargo test --lib` → 41 passed / 0 failed in 3s |

Rust-only, no TypeScript test framework added — the frontend is overwhelmingly IPC wrappers that would need heavy Tauri mocking for low ROI. Happy to add vitest in a follow-up if you want it.

## Roadmap (DESIGN.md §12a)

**Tier 1 (requested, committed):**
- **Login Optimization (M)** — auto-detect SAPISID cookie → drop manual "Done" button, direct Google login URL, headless session probe on launch, inline re-auth toast, guest browse-only mode, Keychain migration for cookies.
- **Themes (L)** — token-override layer on §9, Light/Dark/Dynamic (album-art accent), user JSON themes with zero arbitrary CSS.
- **Focus Mode (M)** — Pomodoro ring on NowPlaying, Rust-side `tokio` timer so UI can close, optional strict mode, SQLite stats.
- **Lyrics (M)** — YTM → LRCLIB fallback, driven by existing 250ms `player:tick`, shares disk cache TTL.

**Tier 2 (researched):** Discord RPC (L), Last.fm / ListenBrainz scrobbling (L), macOS Now Playing + media keys (M), SponsorBlock (M), mini player window (L), customizable shortcuts (L), local playback history SQLite (L), sleep timer (L), resume on launch (L), crossfade (H, deferred).

**Tier 3 (deferred):** EQ / loudness normalization, yt-dlp offline cache, plugin system, on-device lyric translation — each with a documented "why not yet".

**Architectural guardrail**: every new feature must subscribe to the existing event bus or introduce orthogonal Rust state. No feature is allowed to poll the YTM WebView directly — the bridge is the sole reader. Preserves the §1 single-source-of-truth invariant.

## Validation

| Check | Status |
|---|---|
| `cargo check` | clean (6 pre-existing dead_code warnings, unrelated) |
| `pnpm typecheck` | clean |
| `cargo test --lib` | 41 / 41 passing |
| `pnpm tauri dev` boot | window spawned, YTM cookies valid, `browse::get_library_songs done songs=25`, 643 functional log lines, zero errors / panics |

## Test plan

- [ ] Click any track card → plays (exercises `navigate_to_track` + validator)
- [ ] Open a playlist → click a track → plays in playlist context (exercises `navigate_to_track_with_playlist` + playlist ID validator at cap 100)
- [ ] Home / Library / Playlist detail → artwork renders (exercises `cache_fetch_image` + URL allowlist)
- [ ] Settings → cache stats + clear still work
- [ ] Review DESIGN.md §12a roadmap for priority / scope changes before Tier 1 implementation starts