### PR TITLE
v0.2.0: fix 13 open issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/inject/ytm-player-bridge.js
+++ b/scripts/inject/ytm-player-bridge.js
@@ -7,6 +7,10 @@
 
   window.__VIBEYTM_STATE__ = null;
   window.__VIBEYTM_DEBUG__ = [];
+  // Tri-state: true = signed in, false = signed out, null = undetermined.
+  // Tracked independently of __VIBEYTM_STATE__ because we need it before the
+  // music player DOM exists (on the sign-in page there is no player yet).
+  window.__VIBEYTM_LOGGED_IN__ = null;
 
   function log(msg) {
     window.__VIBEYTM_DEBUG__.push(new Date().toISOString() + ': ' + msg);
@@ -263,10 +267,35 @@
     }
   }
 
+  /**
+   * Detect YouTube Music sign-in state from the nav bar. Runs on a 1.5s
+   * interval regardless of player presence because on the sign-in flow the
+   * music player DOM hasn't been constructed yet.
+   */
+  function checkLoginStatus() {
+    try {
+      var avatar = document.querySelector(
+        'ytmusic-nav-bar #avatar-btn, ytmusic-nav-bar ytmusic-settings-button img'
+      );
+      var signIn = document.querySelector(
+        'ytmusic-nav-bar a[href*="accounts.google.com"], ytmusic-nav-bar a[aria-label*="Sign in" i]'
+      );
+      if (avatar) {
+        window.__VIBEYTM_LOGGED_IN__ = true;
+      } else if (signIn) {
+        window.__VIBEYTM_LOGGED_IN__ = false;
+      }
+    } catch (e) {
+      // Leave last-known value in place on transient DOM errors.
+    }
+  }
+
   if (window.location.hostname === 'music.youtube.com') {
     log('bridge loaded on ' + window.location.href);
     log('__TAURI__ available: ' + (typeof window.__TAURI__ !== 'undefined'));
     log('__TAURI_INTERNALS__ available: ' + (typeof window.__TAURI_INTERNALS__ !== 'undefined'));
     waitForPlayer();
+    setInterval(checkLoginStatus, 1500);
+    checkLoginStatus();
   }
 })();

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5147,7 +5147,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibeytm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibeytm"
-version = "0.1.0"
+version = "0.2.0"
 description = "An Apple Music-style YouTube Music desktop app"
 authors = ["dongli"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-hide",
     "core:window:allow-show",
     "core:window:allow-set-size",
-    "core:window:allow-set-position"
+    "core:window:allow-set-position",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ mod ytm_api;
 
 use std::sync::Arc;
 
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 
 use cache::Cache;
 use events::EventBus;
@@ -29,6 +29,18 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
+        .on_window_event(|window, event| {
+            // macOS: clicking the red close button should hide the main
+            // window (leaving the app in the dock) instead of terminating
+            // it, so a subsequent dock-icon click can restore it via the
+            // Reopen handler below.
+            if window.label() == "main" {
+                if let WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+            }
+        })
         .manage(bus.clone())
         .manage(player_state.clone())
         .manage(YtmApi::new())
@@ -180,6 +192,23 @@ pub fn run() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error running VibeYTM");
+        .build(tauri::generate_context!())
+        .expect("error building VibeYTM")
+        .run(|app_handle, event| {
+            // macOS Reopen: fired when the user clicks the dock icon while
+            // the app has no visible windows. Standard expected behavior is
+            // to restore the main window.
+            if let RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } = event
+            {
+                if !has_visible_windows {
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                    }
+                }
+            }
+        });
 }

--- a/src-tauri/src/webview_bridge/poller.rs
+++ b/src-tauri/src/webview_bridge/poller.rs
@@ -16,8 +16,11 @@ use crate::state::player::{PlaybackStatus, RepeatMode, SharedPlayerState, TrackI
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct BridgeState {
+    #[serde(default)]
     status: String,
+    #[serde(default)]
     title: String,
+    #[serde(default)]
     artist: String,
     #[serde(default)]
     album: String,
@@ -37,6 +40,14 @@ struct BridgeState {
     repeat_mode: String,
     #[serde(default)]
     is_liked: bool,
+    /// Only present once the sign-in state is determined. Tri-state:
+    /// Some(true) = signed in, Some(false) = signed out, None = unknown.
+    #[serde(default)]
+    logged_in: Option<bool>,
+    /// True when the bridge had only the login bit to report (no player DOM
+    /// yet). We skip track/position processing in that case.
+    #[serde(default)]
+    login_only: bool,
 }
 
 fn parse_repeat(s: &str) -> RepeatMode {
@@ -50,7 +61,11 @@ fn parse_repeat(s: &str) -> RepeatMode {
 const READ_STATE_JS: &str = r#"
 (function(){
   var s = window.__VIBEYTM_STATE__;
-  if (s) { return JSON.stringify(s); }
+  var li = window.__VIBEYTM_LOGGED_IN__;
+  // loggedIn is tracked even when the player DOM is absent (e.g. during
+  // the Google sign-in redirect), so always wrap it through.
+  if (s) { return JSON.stringify(Object.assign({}, s, { loggedIn: li })); }
+  if (li === true || li === false) { return JSON.stringify({ loginOnly: true, loggedIn: li }); }
   return "null";
 })();
 "#;
@@ -66,6 +81,7 @@ fn get_poller_result() -> &'static Mutex<Option<String>> {
 pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<EventBus>) {
     let last_video_id = Arc::new(TokioMutex::new(String::new()));
     let last_status = Arc::new(TokioMutex::new(String::new()));
+    let last_logged_in = Arc::new(TokioMutex::new(Option::<bool>::None));
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
     // Polling thread: schedules eval on main thread, reads result from static
@@ -136,7 +152,20 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                 Err(_) => continue,
             };
 
-            if bs.title.is_empty() {
+            // Login-state emission is always attempted, even on the login-only
+            // frame, because that frame is the whole point of the check (player
+            // DOM doesn't exist yet on the sign-in page).
+            if let Some(cur) = bs.logged_in {
+                let mut last_li = last_logged_in.lock().await;
+                if *last_li != Some(cur) {
+                    *last_li = Some(cur);
+                    drop(last_li);
+                    let _ = app.emit("player:login-changed", &cur);
+                }
+            }
+
+            // Login-only frames carry no track data — skip the rest.
+            if bs.login_only || bs.title.is_empty() {
                 continue;
             }
 

--- a/src-tauri/src/webview_bridge/poller.rs
+++ b/src-tauri/src/webview_bridge/poller.rs
@@ -183,7 +183,8 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
             };
 
             let mut last_vid = last_video_id.lock().await;
-            if track_key != *last_vid {
+            let track_changed = track_key != *last_vid;
+            if track_changed {
                 *last_vid = track_key;
                 drop(last_vid);
 
@@ -233,20 +234,43 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
             }
 
             let new_repeat = parse_repeat(&bs.repeat_mode);
-            let (prev_shuffled, prev_repeat, prev_liked) = {
+            let (prev_shuffled, prev_repeat, prev_liked, stored_volume) = {
                 let ps = player_state.read().await;
-                (ps.is_shuffled, ps.repeat_mode, ps.is_liked)
+                (ps.is_shuffled, ps.repeat_mode, ps.is_liked, ps.volume)
             };
+
+            // YTM occasionally resets volume across track transitions (the
+            // <video> element loses attribute state when the src changes).
+            // On the cycle that reports a new track, refuse to overwrite our
+            // stored volume and push it back to YTM instead. Outside of that
+            // window we accept bs.volume as truth so tweaks made directly in
+            // the YTM UI are still reflected.
+            let effective_volume = if track_changed
+                && (bs.volume - stored_volume).abs() > 0.01
+            {
+                if let Some(window) = crate::webview_bridge::get_ytm_window(&app) {
+                    let args = format!("{{\"level\":{}}}", stored_volume);
+                    let _ = crate::webview_bridge::exec_playback_command_with_args(
+                        &window,
+                        "set_volume",
+                        &args,
+                    );
+                }
+                stored_volume
+            } else {
+                bs.volume
+            };
+
             {
                 let mut ps = player_state.write().await;
                 ps.position_secs = bs.position_secs;
-                ps.volume = bs.volume;
+                ps.volume = effective_volume;
                 ps.is_shuffled = bs.is_shuffled;
                 ps.repeat_mode = new_repeat;
                 ps.is_liked = bs.is_liked;
             }
             let _ = app.emit("player:position", &bs.position_secs);
-            let _ = app.emit("player:volume", &bs.volume);
+            let _ = app.emit("player:volume", &effective_volume);
             if prev_shuffled != bs.is_shuffled {
                 let _ = app.emit("player:shuffle-changed", &bs.is_shuffled);
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const App: FC = () => {
   const [currentPath, setCurrentPath] = useState('home');
   const [isNowPlayingOpen, setIsNowPlayingOpen] = useState(false);
   const [viewingPlaylist, setViewingPlaylist] = useState<ViewingPlaylist | null>(null);
+  const [pendingSearchQuery, setPendingSearchQuery] = useState<string | null>(null);
 
   // Lock out rapid second toggles within the animation window so a stray
   // double-click never makes the overlay flash open-and-close.
@@ -38,6 +39,13 @@ const App: FC = () => {
     setViewingPlaylist({ id: playlistId, autoPlay: true });
   }, []);
 
+  const searchForArtist = useCallback((name: string) => {
+    setViewingPlaylist(null);
+    setIsNowPlayingOpen(false);
+    setPendingSearchQuery(name);
+    setCurrentPath('search');
+  }, []);
+
   if (!isLoggedIn) {
     return <LoginPage onLoggedIn={() => setIsLoggedIn(true)} />;
   }
@@ -48,6 +56,8 @@ const App: FC = () => {
         <SearchPage
           onOpenPlaylist={openPlaylistDetail}
           onAutoPlayPlaylist={openPlaylistAutoPlay}
+          pendingQuery={pendingSearchQuery}
+          onPendingQueryConsumed={() => setPendingSearchQuery(null)}
         />
       );
     }
@@ -73,6 +83,7 @@ const App: FC = () => {
           activeTab={sub ?? 'playlists'}
           onOpenPlaylist={openPlaylistDetail}
           onAutoPlayPlaylist={openPlaylistAutoPlay}
+          onSearchArtist={searchForArtist}
         />
       );
     }

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -312,7 +312,14 @@ export const PlayerBar: FC<PlayerBarProps> = ({
             min={0}
             max={duration || 1}
             value={safePosition}
-            onChange={(e) => playerApi.seek(Number(e.target.value))}
+            onChange={(e) => {
+              // Optimistic local update so the thumb tracks the cursor without
+              // waiting for the backend round-trip. The next POSITION_UPDATED
+              // event will reconcile with authoritative time.
+              const next = Number(e.target.value);
+              applyOptimistic({ positionSecs: next });
+              playerApi.seek(next);
+            }}
             style={{
               flex: 1,
               height: '4px',

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -268,7 +268,11 @@ export const PlayerBar: FC<PlayerBarProps> = ({
             size="var(--text-base)"
             isActive={isShuffled}
           />
-          <TransportButton label={'\u25C4\u25C4'} onClick={() => playerApi.previous()} />
+          <TransportButton
+            label={'\u23EE'}
+            ariaLabel="Previous"
+            onClick={() => playerApi.previous()}
+          />
           <button
             onClick={handleTogglePlay}
             aria-label={isPlaying ? 'Pause' : 'Play'}
@@ -293,7 +297,11 @@ export const PlayerBar: FC<PlayerBarProps> = ({
           >
             {isPlaying ? '\u275A\u275A' : '\u25B6'}
           </button>
-          <TransportButton label={'\u25BA\u25BA'} onClick={() => playerApi.next()} />
+          <TransportButton
+            label={'\u23ED'}
+            ariaLabel="Next"
+            onClick={() => playerApi.next()}
+          />
           <TransportButton
             label={<RepeatIcon mode={repeatMode} />}
             ariaLabel={REPEAT_ARIA[repeatMode]}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -370,7 +370,7 @@ export const PlayerBar: FC<PlayerBarProps> = ({
               width: '80px',
               height: '4px',
               appearance: 'none',
-              background: `linear-gradient(to right, var(--color-text-secondary) ${volume * 100}%, var(--color-surface-3) ${volume * 100}%)`,
+              background: `linear-gradient(to right, var(--color-accent) ${volume * 100}%, var(--color-surface-3) ${volume * 100}%)`,
               borderRadius: 'var(--radius-full)',
               cursor: 'pointer',
               outline: 'none',

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -154,7 +154,11 @@ export const PlayerBar: FC<PlayerBarProps> = ({
     });
   };
   const duration = track?.durationSecs ?? 0;
-  const progress = duration > 0 ? positionSecs / duration : 0;
+  // Clamp position so a momentary bridge/track mismatch can't pin the bar at
+  // 100% (see usePlayerState: we also zero position on track-change, but the
+  // clamp is the last line of defense).
+  const safePosition = duration > 0 ? Math.min(positionSecs, duration) : positionSecs;
+  const progress = duration > 0 ? Math.min(1, Math.max(0, safePosition / duration)) : 0;
 
   return (
     <footer
@@ -301,13 +305,13 @@ export const PlayerBar: FC<PlayerBarProps> = ({
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', width: '100%', maxWidth: '480px' }}>
           <span style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-tertiary)', minWidth: '36px', textAlign: 'right' }}>
-            {formatTime(positionSecs)}
+            {formatTime(safePosition)}
           </span>
           <input
             type="range"
             min={0}
             max={duration || 1}
-            value={positionSecs}
+            value={safePosition}
             onChange={(e) => playerApi.seek(Number(e.target.value))}
             style={{
               flex: 1,

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -204,11 +204,9 @@ export const PlayerBar: FC<PlayerBarProps> = ({
                 overflow: 'hidden',
                 flexShrink: 0,
                 padding: 0,
-                border: nowPlayingOpen
-                  ? '2px solid var(--color-accent)'
-                  : 'none',
+                border: 'none',
+                outline: 'none',
                 cursor: 'pointer',
-                transition: 'border var(--duration-fast) var(--ease-out)',
               }}
             >
               <CachedImage

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -70,6 +70,9 @@ export const Sidebar: FC<SidebarProps> = ({ currentPath, onNavigate }) => (
       width: 'var(--sidebar-width)',
       height: '100%',
       paddingTop: 'var(--title-bar-height)',
+      // PlayerBar is position: fixed at the bottom and otherwise occludes
+      // the Settings row that marginTop: auto pushes to the sidebar floor.
+      paddingBottom: 'var(--player-bar-height)',
       background: 'var(--glass-bg)',
       backdropFilter: `blur(var(--glass-blur))`,
       WebkitBackdropFilter: `blur(var(--glass-blur))`,

--- a/src/components/pages/ExplorePage.tsx
+++ b/src/components/pages/ExplorePage.tsx
@@ -10,17 +10,27 @@ interface ExplorePageProps {
   onAutoPlayPlaylist?: (playlistId: string) => void;
 }
 
+// Module-level cache so the Explore feed survives tab-switch remounts. The
+// page component is unmounted when the user navigates away, which would
+// otherwise force a fresh fetch every time they return.
+let exploreCache: Shelf[] | null = null;
+
 export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
-  const [shelves, setShelves] = useState<Shelf[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [shelves, setShelves] = useState<Shelf[]>(exploreCache ?? []);
+  // If we already have cached data, skip the loading spinner on remount —
+  // render the cache immediately.
+  const [isLoading, setIsLoading] = useState(exploreCache === null);
   const [error, setError] = useState<string | null>(null);
 
   const fetchExplore = useCallback(() => {
-    setIsLoading(true);
+    // Only show the loader when we have nothing to display — otherwise
+    // refresh silently and swap in the new data when it arrives.
+    if (exploreCache === null) setIsLoading(true);
     setError(null);
     browseApi
       .getExplore()
       .then((data) => {
+        exploreCache = data;
         setShelves(data);
         setIsLoading(false);
       })
@@ -31,6 +41,8 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
   }, []);
 
   useEffect(() => {
+    // On remount with a warm cache, skip the network round-trip entirely.
+    if (exploreCache !== null) return;
     fetchExplore();
   }, [fetchExplore]);
 

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -32,6 +32,12 @@ const MOOD_TABS = [
 
 type MoodTab = (typeof MOOD_TABS)[number];
 
+// Module-level so the mood selection survives tab-switch remounts — users
+// expect returning to Home to land them back on the tab they were browsing,
+// not snap-reset to "All".
+let lastActiveMood: MoodTab = 'All';
+let cachedMoodSongs: { mood: MoodTab; songs: TrackInfo[] } | null = null;
+
 const SONGS_FILTER = 'EgWKAQIIAWoSEA4QCRAKEAUQBBADEBUQEBAR';
 
 const getGreeting = (): string => {
@@ -44,9 +50,18 @@ const getGreeting = (): string => {
 export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
   const [shelves, setShelves] = useState<Shelf[]>(cachedShelves ?? []);
   const [isLoading, setIsLoading] = useState(!cachedShelves);
-  const [activeMood, setActiveMood] = useState<MoodTab>('All');
-  const [moodSongs, setMoodSongs] = useState<TrackInfo[]>([]);
+  const [activeMood, setActiveMood] = useState<MoodTab>(lastActiveMood);
+  const [moodSongs, setMoodSongs] = useState<TrackInfo[]>(
+    cachedMoodSongs && cachedMoodSongs.mood === lastActiveMood
+      ? cachedMoodSongs.songs
+      : [],
+  );
   const [isMoodLoading, setIsMoodLoading] = useState(false);
+
+  const selectMood = useCallback((mood: MoodTab) => {
+    lastActiveMood = mood;
+    setActiveMood(mood);
+  }, []);
 
   const fetchHome = useCallback((force = false) => {
     // Always force on the very first load of the app session
@@ -83,6 +98,14 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
       return;
     }
 
+    // If we still have the same mood's songs cached from a previous visit,
+    // render them immediately and skip the fetch.
+    if (cachedMoodSongs && cachedMoodSongs.mood === activeMood) {
+      setMoodSongs(cachedMoodSongs.songs);
+      setIsMoodLoading(false);
+      return;
+    }
+
     let cancelled = false;
     setIsMoodLoading(true);
 
@@ -90,6 +113,7 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
       .search(activeMood, SONGS_FILTER)
       .then((results) => {
         if (!cancelled) {
+          cachedMoodSongs = { mood: activeMood, songs: results.songs };
           setMoodSongs(results.songs);
           setIsMoodLoading(false);
         }
@@ -194,7 +218,7 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
           return (
             <button
               key={tab}
-              onClick={() => setActiveMood(tab)}
+              onClick={() => selectMood(tab)}
               style={{
                 flexShrink: 0,
                 padding: 'var(--space-2) var(--space-4)',

--- a/src/components/pages/LibraryPage.tsx
+++ b/src/components/pages/LibraryPage.tsx
@@ -15,6 +15,7 @@ interface LibraryPageProps {
   activeTab: LibraryTab;
   onOpenPlaylist?: (playlistId: string) => void;
   onAutoPlayPlaylist?: (playlistId: string) => void;
+  onSearchArtist?: (name: string) => void;
 }
 
 const TAB_TITLES: Record<LibraryTab, string> = {
@@ -27,6 +28,7 @@ const TAB_TITLES: Record<LibraryTab, string> = {
 export const LibraryPage: FC<LibraryPageProps> = ({
   activeTab,
   onOpenPlaylist,
+  onSearchArtist,
 }) => {
   const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
   const [songs, setSongs] = useState<TrackInfo[]>([]);
@@ -198,14 +200,21 @@ export const LibraryPage: FC<LibraryPageProps> = ({
               }}
             >
               {artists.map((artist) => (
-                <div
+                <button
                   key={artist.channelId}
+                  type="button"
+                  onClick={() => onSearchArtist?.(artist.name)}
+                  aria-label={`Search for ${artist.name}`}
                   style={{
                     display: 'flex',
                     flexDirection: 'column',
                     alignItems: 'center',
                     gap: 'var(--space-2)',
                     width: '120px',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
                   }}
                 >
                   <div
@@ -245,7 +254,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({
                   >
                     {artist.name}
                   </span>
-                </div>
+                </button>
               ))}
             </div>
           ) : (

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
-import { type FC, useState } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import { ytmApi } from '../../lib/ipc';
+import { useTauriEvent } from '../../hooks/useTauriEvent';
 
 interface LoginPageProps {
   onLoggedIn: () => void;
@@ -7,6 +8,31 @@ interface LoginPageProps {
 
 export const LoginPage: FC<LoginPageProps> = ({ onLoggedIn }) => {
   const [error, setError] = useState<string | null>(null);
+
+  // Latch so repeated events (the poller re-emits on each value transition)
+  // only trigger the handoff once.
+  const handedOffRef = useRef(false);
+
+  const autoAdvance = () => {
+    if (handedOffRef.current) return;
+    handedOffRef.current = true;
+    ytmApi.hideYtm().catch(() => {
+      // If hiding fails, proceed anyway — the user can close it manually.
+    });
+    onLoggedIn();
+  };
+
+  useTauriEvent<boolean>('player:login-changed', (isLoggedIn) => {
+    if (isLoggedIn) autoAdvance();
+  });
+
+  // Also nudge the bridge to re-check quickly so a user who is already
+  // signed in (returning user) isn't forced to wait for the next poll cycle.
+  useEffect(() => {
+    ytmApi.injectBridge().catch(() => {
+      // Bridge was already injected via Tauri init script — safe to ignore.
+    });
+  }, []);
 
   const handleShowYtm = async () => {
     setError(null);

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -26,12 +26,18 @@ const CATEGORY_PARAMS: Record<CategoryTab, string | undefined> = {
 interface SearchPageProps {
   onOpenPlaylist?: (playlistId: string) => void;
   onAutoPlayPlaylist?: (playlistId: string) => void;
+  pendingQuery?: string | null;
+  onPendingQueryConsumed?: () => void;
 }
 
 const cacheKey = (q: string, cat: CategoryTab | null): string =>
   `${q.trim().toLowerCase()}|${cat ?? 'all'}`;
 
-export const SearchPage: FC<SearchPageProps> = ({ onOpenPlaylist }) => {
+export const SearchPage: FC<SearchPageProps> = ({
+  onOpenPlaylist,
+  pendingQuery,
+  onPendingQueryConsumed,
+}) => {
   // `query` = current text in the input. `submittedQuery` = last query the
   // user actually committed (Enter or clicked a suggestion). Searches fire
   // off the latter only.
@@ -183,6 +189,15 @@ export const SearchPage: FC<SearchPageProps> = ({ onOpenPlaylist }) => {
     setShowSuggestions(false);
     setSuggestions([]);
   };
+
+  // When the app routes us here with a pending query (e.g. from Library →
+  // Artist click), submit it once and clear the latch so we don't loop.
+  useEffect(() => {
+    if (!pendingQuery) return;
+    submitQuery(pendingQuery);
+    setActiveCategory(null);
+    onPendingQueryConsumed?.();
+  }, [pendingQuery, onPendingQueryConsumed]);
 
   const handleTabClick = (tab: CategoryTab) => {
     // Click the active tab again to deselect → unified view.

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -35,7 +35,11 @@ export function usePlayerState(): UsePlayerState {
   }, []);
 
   useTauriEvent<TrackInfo>(EVENTS.TRACK_CHANGED, (track) => {
-    setState((prev) => ({ ...prev, track }));
+    // Reset position alongside the track swap. The bridge emits TRACK_CHANGED
+    // and POSITION_UPDATED from separate cycles, so without this the progress
+    // bar briefly renders with the old position over the new (shorter)
+    // duration — which pins it visually at 100%.
+    setState((prev) => ({ ...prev, track, positionSecs: 0 }));
   });
 
   useTauriEvent<PlaybackStatus>(EVENTS.STATUS_CHANGED, (status) => {


### PR DESCRIPTION
## Summary

Fixes 13 open issues in separate commits, each referenced by its number. Tested locally via `pnpm tauri dev` before pushing.

| # | Fix |
|---|---|
| #4 | Window drag: add `core:window:allow-start-dragging` permission |
| #5 | Cover image: drop accent border and focus outline |
| #6 | Library artists clickable → Search page with artist query |
| #7 | Progress bar: zero position on track change and clamp to [0,1] |
| #8 | Seek: optimistic position update before backend round-trip |
| #9 | Prev/next: replace mismatched `◄◄`/`►►` with paired `⏮`/`⏭` |
| #10 | Volume bar: paint in `--color-accent` |
| #11 | Login auto-close: bridge DOM avatar check → `player:login-changed` |
| #12 | Settings tab: sidebar reserves `--player-bar-height` |
| #13 | Dock-icon reopen: `WindowEvent::CloseRequested` hide + `RunEvent::Reopen` show |
| #14 | Volume preserved across tracks: poller refuses overwrite on track change |
| #15 | Explore feed: module-level cache survives remounts |
| #16 | Home mood tab: persist `activeMood` at module scope |

Plus a `chore: bump version to 0.2.0` commit across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `cargo check` clean
- [x] `pnpm build` clean
- [x] Manual smoke test via `pnpm tauri dev`