### PR TITLE
v0.5.0: fix 13 open issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5147,7 +5147,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibeytm"
-version = "0.2.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibeytm"
-version = "0.2.0"
+version = "0.5.0"
 description = "An Apple Music-style YouTube Music desktop app"
 authors = ["dongli"]
 edition = "2021"

--- a/src-tauri/src/events/types.rs
+++ b/src-tauri/src/events/types.rs
@@ -13,7 +13,7 @@ pub enum AppEvent {
     IntegrationError { source: String, message: String },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlaybackCommand {
     Play,

--- a/src-tauri/src/integrations/global_shortcuts.rs
+++ b/src-tauri/src/integrations/global_shortcuts.rs
@@ -25,32 +25,40 @@ impl Integration for GlobalShortcutsIntegration {
         _state: SharedPlayerState,
         app: AppHandle,
     ) -> Result<()> {
-        let bus_play = bus.clone();
-        let bus_next = bus.clone();
-        let bus_prev = bus.clone();
+        // Chord choices:
+        // - Play/pause: Cmd+Shift+Space (safe globally on macOS/Windows/Linux)
+        // - Next: Cmd+Alt+Right (avoids Ctrl+Right → macOS Mission Control spaces)
+        // - Prev: Cmd+Alt+Left  (avoids Ctrl+Left  → macOS Mission Control spaces)
+        // Some system-reserved chords silently fail to register on macOS, so
+        // log the outcome per-shortcut instead of aborting the whole set.
+        let register = |chord: &str, cmd: PlaybackCommand, bus: Arc<EventBus>| {
+            let res = app
+                .global_shortcut()
+                .on_shortcut(chord, move |_app, _shortcut, _event| {
+                    bus.emit(AppEvent::PlaybackCommand(cmd));
+                });
+            match res {
+                Ok(_) => tracing::info!(chord, ?cmd, "global shortcut registered"),
+                Err(e) => tracing::warn!(chord, ?cmd, error = %e, "failed to register shortcut"),
+            }
+        };
 
-        app.global_shortcut().on_shortcut(
+        register(
             "CommandOrControl+Shift+Space",
-            move |_app, _shortcut, _event| {
-                bus_play.emit(AppEvent::PlaybackCommand(PlaybackCommand::TogglePlay));
-            },
-        )?;
+            PlaybackCommand::TogglePlay,
+            bus.clone(),
+        );
+        register(
+            "CommandOrControl+Alt+Right",
+            PlaybackCommand::Next,
+            bus.clone(),
+        );
+        register(
+            "CommandOrControl+Alt+Left",
+            PlaybackCommand::Previous,
+            bus.clone(),
+        );
 
-        app.global_shortcut().on_shortcut(
-            "CommandOrControl+Shift+Right",
-            move |_app, _shortcut, _event| {
-                bus_next.emit(AppEvent::PlaybackCommand(PlaybackCommand::Next));
-            },
-        )?;
-
-        app.global_shortcut().on_shortcut(
-            "CommandOrControl+Shift+Left",
-            move |_app, _shortcut, _event| {
-                bus_prev.emit(AppEvent::PlaybackCommand(PlaybackCommand::Previous));
-            },
-        )?;
-
-        tracing::info!("global shortcuts registered");
         Ok(())
     }
 

--- a/src-tauri/src/integrations/global_shortcuts.rs
+++ b/src-tauri/src/integrations/global_shortcuts.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use tauri::AppHandle;
-use tauri_plugin_global_shortcut::GlobalShortcutExt;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
 use crate::events::bus::EventBus;
 use crate::events::types::{AppEvent, PlaybackCommand};
@@ -34,7 +34,13 @@ impl Integration for GlobalShortcutsIntegration {
         let register = |chord: &str, cmd: PlaybackCommand, bus: Arc<EventBus>| {
             let res = app
                 .global_shortcut()
-                .on_shortcut(chord, move |_app, _shortcut, _event| {
+                .on_shortcut(chord, move |_app, _shortcut, event| {
+                    // Fires on both Pressed and Released — without this guard
+                    // toggle_play ran twice per keypress and users saw
+                    // pause-then-play in one keystroke.
+                    if event.state() != ShortcutState::Pressed {
+                        return;
+                    }
                     bus.emit(AppEvent::PlaybackCommand(cmd));
                 });
             match res {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,17 @@ pub fn run() {
             })?;
             app.manage(cache);
 
+            // Restore last session (track + position + volume) so the
+            // bottom player shows where the user left off. No autoplay —
+            // status stays idle until the user hits Play.
+            if let Some(session) = state::persistence::load(app.handle()) {
+                let state_for_restore = player_state.clone();
+                tauri::async_runtime::spawn(async move {
+                    state::persistence::apply(&state_for_restore, session).await;
+                });
+            }
+            state::persistence::spawn_saver(app.handle().clone(), player_state.clone());
+
             let integrations = integrations::register_integrations();
             for integration in integrations {
                 let bus = bus.clone();

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,2 +1,3 @@
+pub mod persistence;
 pub mod player;
 pub mod settings;

--- a/src-tauri/src/state/persistence.rs
+++ b/src-tauri/src/state/persistence.rs
@@ -1,0 +1,94 @@
+//! Persist a small slice of PlayerState (last track + position + volume)
+//! across app restarts so users don't lose their place. No autoplay — we
+//! just re-populate the UI so the bottom player bar shows where they left
+//! off; the user has to press Play to resume.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use tokio::time::sleep;
+
+use crate::state::player::{SharedPlayerState, TrackInfo};
+
+const SESSION_FILE: &str = "last_session.json";
+const SAVE_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedSession {
+    pub track: Option<TrackInfo>,
+    pub position_secs: f64,
+    pub volume: f64,
+}
+
+fn session_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_data_dir()
+        .ok()
+        .map(|dir| dir.join(SESSION_FILE))
+}
+
+/// Read a persisted session from disk. Any IO or parse failure returns
+/// None — persistence is best-effort.
+pub fn load(app: &AppHandle) -> Option<PersistedSession> {
+    let path = session_path(app)?;
+    let bytes = std::fs::read(&path).ok()?;
+    let session: PersistedSession = serde_json::from_slice(&bytes).ok()?;
+    tracing::info!(
+        track = ?session.track.as_ref().map(|t| t.title.as_str()),
+        position = session.position_secs,
+        "restored last session"
+    );
+    Some(session)
+}
+
+fn save_sync(app: &AppHandle, session: &PersistedSession) {
+    let Some(path) = session_path(app) else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_json::to_vec_pretty(session) {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(&path, &bytes) {
+                tracing::warn!(error = %e, "failed to write session file");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "failed to serialize session"),
+    }
+}
+
+/// Apply a loaded session to in-memory state. Position and volume are
+/// restored verbatim; playback status stays idle so nothing auto-plays.
+pub async fn apply(state: &SharedPlayerState, session: PersistedSession) {
+    let mut player = state.write().await;
+    player.track = session.track;
+    player.position_secs = session.position_secs;
+    player.volume = session.volume;
+}
+
+/// Spawn a background task that snapshots current state to disk every
+/// SAVE_INTERVAL, but only when something actually changed since the last
+/// save. Runs for the life of the app handle.
+pub fn spawn_saver(app: AppHandle, state: SharedPlayerState) {
+    tauri::async_runtime::spawn(async move {
+        let mut last_saved: Option<PersistedSession> = None;
+        loop {
+            sleep(SAVE_INTERVAL).await;
+            let snapshot = {
+                let player = state.read().await;
+                PersistedSession {
+                    track: player.track.clone(),
+                    position_secs: player.position_secs,
+                    volume: player.volume,
+                }
+            };
+            if last_saved.as_ref() == Some(&snapshot) {
+                continue;
+            }
+            save_sync(&app, &snapshot);
+            last_saved = Some(snapshot);
+        }
+    });
+}

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -197,6 +197,7 @@ const FILTER_ALBUMS: &str = "EgWKAQIYAWoSEA4QCRAKEAUQBBADEBUQEBAR";
 const FILTER_ARTISTS: &str = "EgWKAQIgAWoSEA4QCRAKEAUQBBADEBUQEBAR";
 #[allow(dead_code)]
 const FILTER_VIDEOS: &str = "EgWKAQIQAWoSEA4QCRAKEAUQBBADEBUQEBAR";
+const FILTER_PLAYLISTS: &str = "EgWKAQIoAWoSEA4QCRAKEAUQBBADEBUQEBAR";
 
 /// Extract autocomplete suggestion strings from a `music/get_search_suggestions`
 /// response. The response wraps each suggestion in a `searchSuggestionRenderer`
@@ -229,7 +230,7 @@ fn parse_search_results(data: &Value, filter: Option<&str>) -> SearchResults {
     let mut songs = Vec::new();
     let mut albums = Vec::new();
     let mut artists = Vec::new();
-    let playlists = Vec::new();
+    let mut playlists = Vec::new();
     let mut top_album: Option<AlbumSummary> = None;
 
     let tabs = &data["contents"]["tabbedSearchResultsRenderer"]["tabs"];
@@ -289,6 +290,11 @@ fn parse_search_results(data: &Value, filter: Option<&str>) -> SearchResults {
                         Some(FILTER_ARTISTS) => {
                             if let Some(artist) = parse_artist_from_list_item(renderer) {
                                 artists.push(artist);
+                            }
+                        }
+                        Some(FILTER_PLAYLISTS) => {
+                            if let Some(pl) = parse_playlist_from_list_item(renderer) {
+                                playlists.push(pl);
                             }
                         }
                         _ => {
@@ -997,6 +1003,63 @@ fn parse_artist_from_list_item(renderer: &Value) -> Option<ArtistSummary> {
         name,
         avatar_url,
         subscriber_count,
+    })
+}
+
+/// Parse a playlist from a `musicResponsiveListItemRenderer` in filtered search results.
+fn parse_playlist_from_list_item(renderer: &Value) -> Option<PlaylistSummary> {
+    let flex_columns = renderer["flexColumns"].as_array()?;
+
+    let title = flex_columns
+        .first()
+        .map(|col| runs_text(&col["musicResponsiveListItemFlexColumnRenderer"]["text"]["runs"]))
+        .unwrap_or_default();
+
+    if title.is_empty() {
+        return None;
+    }
+
+    // browseId carries a VL-prefixed playlist ID in the renderer-level
+    // navigationEndpoint; the overlay play button exposes the raw playlistId.
+    let raw_browse = renderer["navigationEndpoint"]["browseEndpoint"]["browseId"]
+        .as_str()
+        .unwrap_or_default();
+    let overlay_playlist = renderer["overlay"]["musicItemThumbnailOverlayRenderer"]["content"]
+        ["musicPlayButtonRenderer"]["playNavigationEndpoint"]["watchPlaylistEndpoint"]["playlistId"]
+        .as_str()
+        .unwrap_or_default();
+
+    let playlist_id = if !overlay_playlist.is_empty() {
+        overlay_playlist.to_string()
+    } else if let Some(stripped) = raw_browse.strip_prefix("VL") {
+        stripped.to_string()
+    } else if !raw_browse.is_empty() {
+        raw_browse.to_string()
+    } else {
+        return None;
+    };
+
+    // Track count — secondary column often reads "Playlist • Author • N songs".
+    let subtitle = flex_columns
+        .get(1)
+        .map(|col| runs_text(&col["musicResponsiveListItemFlexColumnRenderer"]["text"]["runs"]))
+        .unwrap_or_default();
+    let track_count = subtitle.split(" \u{2022} ").find_map(|part| {
+        part.trim()
+            .split_whitespace()
+            .next()
+            .and_then(|n| n.parse::<u32>().ok())
+    });
+
+    let artwork_url = best_thumbnail(
+        &renderer["thumbnail"]["musicThumbnailRenderer"]["thumbnail"]["thumbnails"],
+    );
+
+    Some(PlaylistSummary {
+        playlist_id,
+        title,
+        artwork_url,
+        track_count,
     })
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ const App: FC = () => {
   const [isNowPlayingOpen, setIsNowPlayingOpen] = useState(false);
   const [viewingPlaylist, setViewingPlaylist] = useState<ViewingPlaylist | null>(null);
   const [pendingSearchQuery, setPendingSearchQuery] = useState<string | null>(null);
+  // Remembered so "Settings → Settings" toggles back to where the user was.
+  const previousPathRef = useRef<string>('home');
 
   // Lock out rapid second toggles within the animation window so a stray
   // double-click never makes the overlay flash open-and-close.
@@ -101,6 +103,18 @@ const App: FC = () => {
       onNavigate={(path) => {
         setViewingPlaylist(null);
         setIsNowPlayingOpen(false);
+        // Settings tab toggles: clicking it while open returns to the
+        // previous view instead of re-rendering the same page.
+        if (path === 'settings' && currentPath === 'settings') {
+          const fallback = previousPathRef.current === 'settings'
+            ? 'home'
+            : previousPathRef.current;
+          setCurrentPath(fallback);
+          return;
+        }
+        if (path !== currentPath) {
+          previousPathRef.current = currentPath;
+        }
         setCurrentPath(path);
       }}
       nowPlayingOpen={isNowPlayingOpen}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -378,7 +378,14 @@ export const PlayerBar: FC<PlayerBarProps> = ({
             min={0}
             max={100}
             value={Math.round(volume * 100)}
-            onChange={(e) => playerApi.setVolume(Number(e.target.value) / 100)}
+            onChange={(e) => {
+              // Optimistic local update so the thumb and gradient track the
+              // cursor on click/drag instead of waiting for the backend →
+              // YTM → VOLUME_CHANGED round-trip.
+              const next = Number(e.target.value) / 100;
+              applyOptimistic({ volume: next });
+              playerApi.setVolume(next);
+            }}
             style={{
               width: '80px',
               height: '4px',

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -119,7 +119,7 @@ export const PlayerBar: FC<PlayerBarProps> = ({
   nowPlayingOpen = false,
 }) => {
   const state = usePlayerState();
-  const { track, status, positionSecs, volume, isShuffled, repeatMode, isLiked, applyOptimistic } = state;
+  const { track, status, positionSecs, volume, isShuffled, repeatMode, isLiked, applyOptimistic, markSeek } = state;
   const isPlaying = status === 'playing';
 
   const handleTogglePlay = () => {
@@ -327,9 +327,11 @@ export const PlayerBar: FC<PlayerBarProps> = ({
             value={duration > 0 ? safePosition : 0}
             onChange={(e) => {
               // Optimistic local update so the thumb tracks the cursor without
-              // waiting for the backend round-trip. The next POSITION_UPDATED
-              // event will reconcile with authoritative time.
+              // waiting for the backend round-trip. markSeek lets the hook
+              // discard stale pre-seek position echoes from the bridge poller
+              // that would otherwise bounce the thumb back to the old spot.
               const next = Number(e.target.value);
+              markSeek(next);
               applyOptimistic({ positionSecs: next });
               playerApi.seek(next);
             }}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -334,6 +334,14 @@ export const PlayerBar: FC<PlayerBarProps> = ({
               markSeek(next);
               applyOptimistic({ positionSecs: next });
               playerApi.seek(next);
+              // If the user scrubs while paused, treat the click as "resume
+              // here" — standard behavior across music players.
+              if (!isPlaying) {
+                applyOptimistic({ status: 'playing' });
+                playerApi.play().catch(() => {
+                  applyOptimistic({ status: 'paused' });
+                });
+              }
             }}
             style={{
               flex: 1,

--- a/src/components/pages/ExplorePage.tsx
+++ b/src/components/pages/ExplorePage.tsx
@@ -20,12 +20,14 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
   // If we already have cached data, skip the loading spinner on remount —
   // render the cache immediately.
   const [isLoading, setIsLoading] = useState(exploreCache === null);
+  // Separate flag for explicit user-triggered refreshes so the button can
+  // show feedback (spin + disabled) without swapping out the whole page.
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchExplore = useCallback(() => {
-    // Only show the loader when we have nothing to display — otherwise
-    // refresh silently and swap in the new data when it arrives.
+  const fetchExplore = useCallback((userInitiated = false) => {
     if (exploreCache === null) setIsLoading(true);
+    if (userInitiated) setIsRefreshing(true);
     setError(null);
     browseApi
       .getExplore()
@@ -33,10 +35,12 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
         exploreCache = data;
         setShelves(data);
         setIsLoading(false);
+        setIsRefreshing(false);
       })
       .catch((e) => {
         setError(String(e));
         setIsLoading(false);
+        setIsRefreshing(false);
       });
   }, []);
 
@@ -84,7 +88,7 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
           Failed to load explore content
         </p>
         <button
-          onClick={fetchExplore}
+          onClick={() => fetchExplore()}
           style={{
             background: 'none',
             border: '1px solid var(--color-border)',
@@ -137,18 +141,41 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
           Explore
         </h1>
         <button
-          onClick={fetchExplore}
+          onClick={() => {
+            if (isRefreshing) return;
+            // Drop the cache so the fetch can't short-circuit against a
+            // stale payload, and force a fresh request.
+            exploreCache = null;
+            fetchExplore(true);
+          }}
+          disabled={isRefreshing}
+          aria-busy={isRefreshing}
           style={{
             background: 'none',
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-md)',
             padding: 'var(--space-1) var(--space-3)',
             color: 'var(--color-text-tertiary)',
-            cursor: 'pointer',
+            cursor: isRefreshing ? 'wait' : 'pointer',
             fontSize: 'var(--text-sm)',
+            opacity: isRefreshing ? 0.6 : 1,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 'var(--space-1)',
           }}
         >
-          ↻ Refresh
+          <span
+            style={{
+              display: 'inline-block',
+              transition: 'transform var(--duration-normal) var(--ease-out)',
+              animation: isRefreshing
+                ? 'vibeytm-spin 0.9s linear infinite'
+                : undefined,
+            }}
+          >
+            ↻
+          </span>
+          {isRefreshing ? 'Refreshing…' : 'Refresh'}
         </button>
       </div>
 

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -117,6 +117,71 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
     return null;
   }
 
+  // Shows ('Your shows' / 'Shows for You' on home) surface through the same
+  // onOpenPlaylist callback as albums/playlists, but their browseIds don't
+  // resolve to a track-bearing playlist. Detect the empty-shell response
+  // (no title AND no tracks) and render a friendly coming-soon placeholder
+  // instead of a confusing blank page.
+  if (playlist.tracks.length === 0 && !playlist.title) {
+    return (
+      <section
+        style={{
+          padding: 'var(--space-6) var(--space-6) var(--space-8)',
+          height: '100%',
+          overflowY: 'auto',
+        }}
+      >
+        <button
+          onClick={onBack}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'var(--color-text-secondary)',
+            cursor: 'pointer',
+            fontSize: 'var(--text-sm)',
+            padding: 'var(--space-1) 0',
+            marginBottom: 'var(--space-6)',
+          }}
+        >
+          &larr; Back
+        </button>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 'var(--space-2)',
+            minHeight: '50vh',
+            textAlign: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 'var(--text-2xl)',
+              fontWeight: 700,
+              color: 'var(--color-text-primary)',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Shows coming soon
+          </div>
+          <p
+            style={{
+              fontSize: 'var(--text-sm)',
+              color: 'var(--color-text-tertiary)',
+              maxWidth: '360px',
+              lineHeight: 1.5,
+            }}
+          >
+            Podcast and show playback isn't available in VibeYTM yet.
+            We're working on it.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section
       style={{

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -12,15 +12,14 @@ const MIN_SUGGEST_LENGTH = 3;
 const MAX_SUGGESTIONS = 5;
 const PREVIEW_TRACK_COUNT = 3;
 
-const CATEGORY_TABS = ['Songs', 'Albums', 'Artists', 'Videos', 'Playlists'] as const;
+const CATEGORY_TABS = ['Songs', 'Albums', 'Artists', 'Playlists'] as const;
 type CategoryTab = (typeof CATEGORY_TABS)[number];
 
 const CATEGORY_PARAMS: Record<CategoryTab, string | undefined> = {
   Songs: 'EgWKAQIIAWoSEA4QCRAKEAUQBBADEBUQEBAR',
   Albums: 'EgWKAQIYAWoSEA4QCRAKEAUQBBADEBUQEBAR',
   Artists: 'EgWKAQIgAWoSEA4QCRAKEAUQBBADEBUQEBAR',
-  Videos: 'EgWKAQIQAWoSEA4QCRAKEAUQBBADEBUQEBAR',
-  Playlists: undefined,
+  Playlists: 'EgWKAQIoAWoSEA4QCRAKEAUQBBADEBUQEBAR',
 };
 
 interface SearchPageProps {
@@ -687,13 +686,6 @@ export const SearchPage: FC<SearchPageProps> = ({
         </>
       )}
 
-      {!isLoading && results && activeCategory === 'Videos' && (
-        <ComingSoon label="Video search" />
-      )}
-
-      {!isLoading && results && activeCategory === 'Playlists' && (
-        <ComingSoon label="Playlist search" />
-      )}
     </section>
   );
 };

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -605,6 +605,42 @@ export const SearchPage: FC<SearchPageProps> = ({
         </>
       )}
 
+      {!isLoading && results && activeCategory === 'Playlists' && (
+        <>
+          {results.playlists.length > 0 ? (
+            <ShelfRow title="Playlists">
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+                  gap: '20px',
+                }}
+              >
+                {results.playlists.map((playlist) => (
+                  <AlbumCard
+                    key={playlist.playlistId}
+                    artworkUrl={playlist.artworkUrl}
+                    title={playlist.title}
+                    subtitle={
+                      playlist.trackCount !== undefined
+                        ? `${playlist.trackCount} tracks`
+                        : ''
+                    }
+                    onClick={() => onOpenPlaylist?.(playlist.playlistId)}
+                    onPlay={() => {
+                      playFirstFromPlaylist(playlist.playlistId);
+                      onOpenPlaylist?.(playlist.playlistId);
+                    }}
+                  />
+                ))}
+              </div>
+            </ShelfRow>
+          ) : (
+            <EmptyCategory label="playlists" />
+          )}
+        </>
+      )}
+
       {!isLoading && results && activeCategory === 'Artists' && (
         <>
           {results.artists.length > 0 ? (
@@ -794,22 +830,3 @@ const EmptyCategory: FC<{ label: string }> = ({ label }) => (
   </div>
 );
 
-const ComingSoon: FC<{ label: string }> = ({ label }) => (
-  <div
-    style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      minHeight: '200px',
-    }}
-  >
-    <p
-      style={{
-        fontSize: 'var(--text-base)',
-        color: 'var(--color-text-tertiary)',
-      }}
-    >
-      {label} coming soon
-    </p>
-  </div>
-);

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -9,6 +9,13 @@ import { useTauriEvent } from './useTauriEvent';
 // values from the YTM bridge poller.
 const VOLUME_ECHO_WINDOW_MS = 500;
 
+// After a manual seek, POSITION_UPDATED events emitted before YTM finished
+// seeking carry pre-seek timestamps that would visually bounce the thumb
+// back to the old position. Drop those within this reconciliation window
+// ONLY if they are far from the seek target.
+const SEEK_RECONCILE_WINDOW_MS = 800;
+const SEEK_TOLERANCE_SECS = 2;
+
 const DEFAULT_STATE: PlayerState = {
   status: 'idle',
   track: null,
@@ -27,11 +34,18 @@ export interface UsePlayerState extends PlayerState {
    * so the UI updates instantly. The next backend event overwrites it.
    */
   applyOptimistic: (patch: Partial<PlayerState>) => void;
+  /**
+   * Record a user-initiated seek target. Lets the POSITION_UPDATED handler
+   * discard stale pre-seek echoes that would otherwise bounce the thumb.
+   */
+  markSeek: (target: number) => void;
 }
 
 export function usePlayerState(): UsePlayerState {
   const [state, setState] = useState<PlayerState>(DEFAULT_STATE);
   const lastLocalVolumeAtRef = useRef(0);
+  const lastSeekAtRef = useRef(0);
+  const seekTargetRef = useRef(0);
 
   useEffect(() => {
     playerApi.getState().then((s) => {
@@ -54,6 +68,17 @@ export function usePlayerState(): UsePlayerState {
   });
 
   useTauriEvent<number>(EVENTS.POSITION_UPDATED, (positionSecs) => {
+    // Reject pre-seek stragglers: if a position event arrives right after
+    // a manual seek and is still far from the seek target, it's stale data
+    // from before YTM actually seeked. The next event that lands near the
+    // target (or after the reconcile window) will resume normal flow.
+    const sinceSeek = Date.now() - lastSeekAtRef.current;
+    if (
+      sinceSeek < SEEK_RECONCILE_WINDOW_MS &&
+      Math.abs(positionSecs - seekTargetRef.current) > SEEK_TOLERANCE_SECS
+    ) {
+      return;
+    }
     setState((prev) => ({ ...prev, positionSecs }));
   });
 
@@ -90,5 +115,10 @@ export function usePlayerState(): UsePlayerState {
     setState((prev) => ({ ...prev, ...patch }));
   }, []);
 
-  return { ...state, applyOptimistic };
+  const markSeek = useCallback((target: number) => {
+    lastSeekAtRef.current = Date.now();
+    seekTargetRef.current = target;
+  }, []);
+
+  return { ...state, applyOptimistic, markSeek };
 }

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -1,8 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PlayerState, PlaybackStatus, RepeatMode, TrackInfo } from '../lib/types';
 import { playerApi } from '../lib/ipc';
 import { EVENTS } from '../lib/events';
 import { useTauriEvent } from './useTauriEvent';
+
+// Drop VOLUME_CHANGED echoes that arrive within this window of a local
+// optimistic set, so fast drags aren't overwritten by stale intermediate
+// values from the YTM bridge poller.
+const VOLUME_ECHO_WINDOW_MS = 500;
 
 const DEFAULT_STATE: PlayerState = {
   status: 'idle',
@@ -26,6 +31,7 @@ export interface UsePlayerState extends PlayerState {
 
 export function usePlayerState(): UsePlayerState {
   const [state, setState] = useState<PlayerState>(DEFAULT_STATE);
+  const lastLocalVolumeAtRef = useRef(0);
 
   useEffect(() => {
     playerApi.getState().then((s) => {
@@ -52,6 +58,12 @@ export function usePlayerState(): UsePlayerState {
   });
 
   useTauriEvent<number>(EVENTS.VOLUME_CHANGED, (volume) => {
+    // During a local drag, the bridge poller can emit intermediate values
+    // from before the latest set_volume took effect. Those echoes would
+    // overwrite the fresh optimistic state and the thumb would jitter.
+    if (Date.now() - lastLocalVolumeAtRef.current < VOLUME_ECHO_WINDOW_MS) {
+      return;
+    }
     setState((prev) => ({ ...prev, volume }));
   });
 
@@ -72,6 +84,9 @@ export function usePlayerState(): UsePlayerState {
   });
 
   const applyOptimistic = useCallback((patch: Partial<PlayerState>) => {
+    if (patch.volume !== undefined) {
+      lastLocalVolumeAtRef.current = Date.now();
+    }
     setState((prev) => ({ ...prev, ...patch }));
   }, []);
 

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -16,6 +16,12 @@ const VOLUME_ECHO_WINDOW_MS = 500;
 const SEEK_RECONCILE_WINDOW_MS = 800;
 const SEEK_TOLERANCE_SECS = 2;
 
+// After a track change, the bridge poller can still emit one or two
+// POSITION_UPDATED events from the OLD track. If the new track is shorter
+// than the old position, the clamp in PlayerBar pins the thumb at 100%
+// for a frame before normal updates arrive. Drop those stragglers.
+const TRACK_CHANGE_RECONCILE_WINDOW_MS = 1000;
+
 const DEFAULT_STATE: PlayerState = {
   status: 'idle',
   track: null,
@@ -46,6 +52,7 @@ export function usePlayerState(): UsePlayerState {
   const lastLocalVolumeAtRef = useRef(0);
   const lastSeekAtRef = useRef(0);
   const seekTargetRef = useRef(0);
+  const lastTrackChangeAtRef = useRef(0);
 
   useEffect(() => {
     playerApi.getState().then((s) => {
@@ -60,6 +67,7 @@ export function usePlayerState(): UsePlayerState {
     // and POSITION_UPDATED from separate cycles, so without this the progress
     // bar briefly renders with the old position over the new (shorter)
     // duration — which pins it visually at 100%.
+    lastTrackChangeAtRef.current = Date.now();
     setState((prev) => ({ ...prev, track, positionSecs: 0 }));
   });
 
@@ -68,15 +76,29 @@ export function usePlayerState(): UsePlayerState {
   });
 
   useTauriEvent<number>(EVENTS.POSITION_UPDATED, (positionSecs) => {
+    const now = Date.now();
     // Reject pre-seek stragglers: if a position event arrives right after
     // a manual seek and is still far from the seek target, it's stale data
     // from before YTM actually seeked. The next event that lands near the
     // target (or after the reconcile window) will resume normal flow.
-    const sinceSeek = Date.now() - lastSeekAtRef.current;
     if (
-      sinceSeek < SEEK_RECONCILE_WINDOW_MS &&
+      now - lastSeekAtRef.current < SEEK_RECONCILE_WINDOW_MS &&
       Math.abs(positionSecs - seekTargetRef.current) > SEEK_TOLERANCE_SECS
     ) {
+      return;
+    }
+    // Reject old-track stragglers: right after TRACK_CHANGED, drop any
+    // POSITION_UPDATED whose value exceeds the new track's duration — those
+    // timestamps belong to the previous song and cause the "jump to 100%
+    // then back to 0" flash on track switches.
+    if (now - lastTrackChangeAtRef.current < TRACK_CHANGE_RECONCILE_WINDOW_MS) {
+      setState((prev) => {
+        const duration = prev.track?.durationSecs ?? 0;
+        if (duration > 0 && positionSecs > duration) {
+          return prev;
+        }
+        return { ...prev, positionSecs };
+      });
       return;
     }
     setState((prev) => ({ ...prev, positionSecs }));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,3 +62,12 @@ input {
   font: inherit;
   color: inherit;
 }
+
+@keyframes vibeytm-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #17, #18, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #31.

13 open issues fixed — one commit per issue, plus a version bump to 0.5.0.

## Issues addressed

| # | Fix |
|---|---|
| 17 | Remap prev/next global shortcuts to `Cmd+Alt+Left/Right` (avoids macOS Mission Control) and ignore key-release events so a single keystroke doesn't fire twice |
| 18 | Implement the Playlists search tab (adds `FILTER_PLAYLISTS` + backend parser + frontend render) |
| 20 | Drop stale `POSITION_UPDATED` events whose value exceeds the new track's duration within 1s of `TRACK_CHANGED` — removes the flash-to-100% on track switch |
| 21 | Optimistic volume update on click so the thumb moves on the same frame |
| 22 | `markSeek` helper + stale-echo rejection (within 800 ms, >2 s off target) to stop the progress bar bouncing back after a click |
| 23 | Remove the Videos tab from search results |
| 24 | Persist `{track, positionSecs, volume}` to `{app_data}/last_session.json` every 5 s; restore on launch — no autoplay, status stays idle |
| 25 | Clicking Settings while it's already open returns to the previous view |
| 26/27 | Detect empty-shell responses (no title, no tracks) from podcast-show browseIds and render a "Shows coming soon" placeholder |
| 28 | Clicking the progress bar while paused now seeks AND resumes playback |
| 29 | Gate `VOLUME_CHANGED` echoes for 500 ms after a local set so fast drags aren't overwritten by the bridge poller |
| 31 | Explore `Refresh` button now shows spinning feedback, disables while fetching, and busts the module cache so results actually reload |

## Test plan

- [ ] Global shortcuts while unfocused: `Cmd+Shift+Space`, `Cmd+Alt+Right`, `Cmd+Alt+Left` each fires exactly once
- [ ] Search → Playlists tab renders results
- [ ] Switching from a long song to a short one — no 100% flash
- [ ] Volume bar: click lands instantly; fast drag tracks the cursor
- [ ] Progress bar: click lands once, no bounce-back; clicking while paused resumes playback
- [ ] Search: no Videos tab
- [ ] Quit with a song loaded → relaunch → bottom bar shows that track/position, Play button resumes
- [ ] Settings → Settings returns to previous page
- [ ] Home → click "Your shows" / "Shows for You" card → "Shows coming soon" placeholder
- [ ] Explore Refresh: spinning icon + disabled state + reloaded shelves

🤖 Generated with [Claude Code](https://claude.com/claude-code)