### PR TITLE
0.6.0: fix 10 oldest open issues

### DIFF
--- a/TEST_CHECKLIST.md
+++ b/TEST_CHECKLIST.md
@@ -41,6 +41,21 @@ Apply to: Home, Search (Albums/Artists tabs), Explore, Library, Playlist detail
 - **Volume slider**: Rust stores volume as 0.0-1.0 but slider expects 0-100. Fixed
   with `Math.round(volume * 100)`.
 
+## Regression Checklist for 0.6.0
+- [ ] **#34** Track duration renders correctly on start (no 4:12-shown-as-0:29)
+- [ ] **#34** Duration never shrinks once a real length is reported
+- [ ] **#35** Settings page shows ⌘⇧Space / ⌘⌥→ / ⌘⌥← matching registered shortcuts
+- [ ] **#36 / #42** Clicking the volume bar lands on the target position, no bounce
+- [ ] **#37** After sign-out, player bar returns to "No track playing" and sidebar
+      avatar clears within ~2s
+- [ ] **#38** Sidebar avatar/name do NOT flicker on track change
+- [ ] **#39** Cover art shows album artwork (not the video frame) for songs with
+      music videos such as "Despacito — Pop Version"
+- [ ] **#40** A track that stalls at 0:00 auto-recovers within ~4 seconds
+- [ ] **#41** Clicking the progress bar while playing does NOT flash paused
+- [ ] **#43** "Close to tray" toggle persists across restarts. With it OFF, the
+      red close button exits the app. With it ON, the app hides to the tray.
+
 ## Login Flow
 - [ ] App launches with two windows (VibeYTM + YouTube Music)
 - [ ] YouTube Music page loads without "unsupported browser" error

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/inject/ytm-player-bridge.js
+++ b/scripts/inject/ytm-player-bridge.js
@@ -33,12 +33,20 @@
 
     var titleEl = document.querySelector('.title.ytmusic-player-bar');
     var artistEl = document.querySelector('.byline.ytmusic-player-bar a:first-of-type');
-    var imgEl = document.querySelector('.image.ytmusic-player-bar img');
+    // Prefer the expanded song-image (right-hand now-playing panel) because
+    // it shows the *album* artwork even for songs that also have a music
+    // video — issue #39. The small bar thumbnail is our second choice and
+    // the bar's ytmusic-player-bar image is the last resort.
+    var imgEl =
+      document.querySelector('ytmusic-player-page .song-image img') ||
+      document.querySelector('ytmusic-player-page img.thumbnail-image') ||
+      document.querySelector('.image.ytmusic-player-bar img');
 
     // Get video ID — prefer getVideoData() (authoritative) over URL (may lag)
     var videoId = '';
+    var vdata = null;
     try {
-      var vdata = player.getVideoData ? player.getVideoData() : null;
+      vdata = player.getVideoData ? player.getVideoData() : null;
       if (vdata && vdata.video_id) videoId = vdata.video_id;
     } catch(e) {}
     if (!videoId) {
@@ -120,6 +128,20 @@
       }
     } catch(e) {}
 
+    // YTM's getDuration() returns 0 for a few cycles while the <video>
+    // element buffers, and on some tracks it reports a fractional/buffered
+    // length (4:12 shown as 0:29). getVideoData().lengthSeconds is the
+    // authoritative track length published by the player metadata. Prefer
+    // it when present and only fall back to getDuration() otherwise.
+    var lengthFromData = 0;
+    try {
+      if (vdata && typeof vdata.lengthSeconds !== 'undefined') {
+        lengthFromData = Number(vdata.lengthSeconds) || 0;
+      }
+    } catch(e) {}
+    var rawDuration = player.getDuration() || 0;
+    var durationSecs = lengthFromData > 0 ? lengthFromData : rawDuration;
+
     window.__VIBEYTM_STATE__ = {
       status: stateMap[rawState] || 'idle',
       title: titleEl ? titleEl.textContent.trim() : '',
@@ -128,7 +150,7 @@
       artworkUrl: artworkUrl,
       videoId: videoId,
       positionSecs: player.getCurrentTime() || 0,
-      durationSecs: player.getDuration() || 0,
+      durationSecs: durationSecs,
       volume: (player.getVolume() || 0) / 100,
       isShuffled: shuffleOn,
       repeatMode: repeatMode,
@@ -258,10 +280,77 @@
     }
   };
 
+  /**
+   * Watchdog for issue #40: songs occasionally start, then stall at 0:00
+   * with status "playing" or "buffering" — the <video> element is ready
+   * but playback never actually begins. If we stay at position 0 for
+   * STUCK_THRESHOLD_MS without any progress, nudge YTM with a play() call
+   * (and, on a second offense, re-seek to 0) to kick the pipeline awake.
+   */
+  var STUCK_THRESHOLD_MS = 4000;
+  var lastPositionSample = -1;
+  var stuckSinceMs = 0;
+  var stuckRetries = 0;
+  function checkStuck() {
+    var s = window.__VIBEYTM_STATE__;
+    if (!s || !s.videoId) {
+      stuckSinceMs = 0;
+      stuckRetries = 0;
+      return;
+    }
+    // Only watch when YTM claims to be playing or buffering — a deliberately
+    // paused track at 0s isn't stuck.
+    if (s.status !== 'playing' && s.status !== 'buffering') {
+      stuckSinceMs = 0;
+      stuckRetries = 0;
+      lastPositionSample = s.positionSecs;
+      return;
+    }
+    var pos = s.positionSecs || 0;
+    if (pos > 0.25 || pos !== lastPositionSample) {
+      // Progress is happening (or at least the position moved) — reset.
+      if (pos > lastPositionSample) {
+        stuckSinceMs = 0;
+        stuckRetries = 0;
+      }
+      lastPositionSample = pos;
+      if (pos > 0.25) return;
+    }
+    if (stuckSinceMs === 0) {
+      stuckSinceMs = Date.now();
+      return;
+    }
+    if (Date.now() - stuckSinceMs < STUCK_THRESHOLD_MS) return;
+
+    var player = getPlayer();
+    if (!player) return;
+    log('stuck at 0s for ' + (Date.now() - stuckSinceMs) + 'ms — retry ' + stuckRetries);
+    try {
+      if (stuckRetries === 0) {
+        player.playVideo();
+      } else if (stuckRetries === 1) {
+        player.seekTo(0, true);
+        player.playVideo();
+      } else {
+        // Last resort: reload the same track via a fresh navigation. Using
+        // the anchor-click SPA path avoids a full page reload.
+        var a = document.createElement('a');
+        a.href = '/watch?v=' + s.videoId;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function(){ try { document.body.removeChild(a); } catch(e){} }, 100);
+      }
+    } catch(e) {}
+    stuckRetries += 1;
+    stuckSinceMs = Date.now();
+  }
+
   function waitForPlayer() {
     if (getPlayer()) {
       log('player found');
       setInterval(update, 150);
+      setInterval(checkStuck, 1000);
       update();
     } else {
       log('waiting for player...');

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5147,7 +5147,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibeytm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibeytm"
-version = "0.5.0"
+version = "0.6.0"
 description = "An Apple Music-style YouTube Music desktop app"
 authors = ["dongli"]
 edition = "2021"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod browse;
 pub mod cache;
 pub mod player;
+pub mod settings;
 
 pub use player::*;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,27 @@
+use tauri::{AppHandle, State};
+
+use crate::state::settings::{self, AppSettings, SharedSettings};
+
+#[tauri::command]
+pub async fn get_settings(
+    state: State<'_, SharedSettings>,
+) -> Result<AppSettings, String> {
+    Ok(state.read().await.clone())
+}
+
+#[tauri::command]
+pub async fn set_settings(
+    new: AppSettings,
+    state: State<'_, SharedSettings>,
+    app: AppHandle,
+) -> Result<(), String> {
+    {
+        let mut s = state.write().await;
+        *s = new.clone();
+    }
+    // Persist eagerly: the primary reason to flip "close to tray" is to see
+    // the new behavior on the very next close. A delayed debounce would
+    // miss that intent, and the payload is tiny (~250 B).
+    settings::save(&app, &new);
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 use cache::Cache;
 use events::EventBus;
 use state::player::SharedPlayerState;
+use state::settings::SharedSettings;
 use ytm_api::YtmApi;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -23,6 +24,10 @@ pub fn run() {
 
     let bus = Arc::new(EventBus::new());
     let player_state: SharedPlayerState = SharedPlayerState::default();
+    // Settings are loaded lazily on setup (we need an AppHandle to find the
+    // data dir), so initialize the shared wrapper with defaults here.
+    let settings_state: SharedSettings =
+        std::sync::Arc::new(tokio::sync::RwLock::new(Default::default()));
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -33,16 +38,31 @@ pub fn run() {
             // macOS: clicking the red close button should hide the main
             // window (leaving the app in the dock) instead of terminating
             // it, so a subsequent dock-icon click can restore it via the
-            // Reopen handler below.
+            // Reopen handler below. The "Close to tray" setting gates this
+            // behavior — when disabled, the red button quits the app like
+            // a conventional desktop program (issue #43).
             if window.label() == "main" {
                 if let WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                    let _ = window.hide();
+                    let close_to_tray = window
+                        .app_handle()
+                        .try_state::<SharedSettings>()
+                        .map(|s| state::settings::read_blocking(&s).general.close_to_tray)
+                        .unwrap_or(true);
+                    if close_to_tray {
+                        api.prevent_close();
+                        let _ = window.hide();
+                    } else {
+                        // Let the event proceed; Tauri will close the window,
+                        // and since it's the last visible window the app
+                        // exits on macOS/Win/Linux alike.
+                        window.app_handle().exit(0);
+                    }
                 }
             }
         })
         .manage(bus.clone())
         .manage(player_state.clone())
+        .manage(settings_state.clone())
         .manage(YtmApi::new())
         .invoke_handler(tauri::generate_handler![
             commands::on_track_changed,
@@ -83,8 +103,20 @@ pub fn run() {
             commands::cache::cache_stats,
             commands::cache::cache_get_track,
             commands::cache::cache_put_track,
+            commands::settings::get_settings,
+            commands::settings::set_settings,
         ])
         .setup(move |app| {
+            // Load persisted settings before registering integrations so a
+            // future preference that gates an integration would see it.
+            let loaded_settings = state::settings::load(app.handle());
+            {
+                let settings_clone = settings_state.clone();
+                tauri::async_runtime::block_on(async move {
+                    *settings_clone.write().await = loaded_settings;
+                });
+            }
+
             tray::setup_tray(app.handle(), bus.clone())?;
 
             // Initialize disk cache at {app_data}/cache

--- a/src-tauri/src/state/settings.rs
+++ b/src-tauri/src/state/settings.rs
@@ -1,6 +1,17 @@
-use serde::{Deserialize, Serialize};
+//! User-editable app settings. Persisted to `{app_data}/settings.json` so
+//! choices like "close to tray" survive restarts and can be read from the
+//! window-event handler at close time.
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use tokio::sync::RwLock;
+
+const SETTINGS_FILE: &str = "settings.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
     pub general: GeneralSettings,
@@ -8,20 +19,20 @@ pub struct AppSettings {
     pub shortcuts: ShortcutSettings,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneralSettings {
     pub close_to_tray: bool,
     pub background_playback: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct IntegrationSettings {
     pub notifications_enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ShortcutSettings {
     pub play_pause: String,
@@ -41,9 +52,90 @@ impl Default for AppSettings {
             },
             shortcuts: ShortcutSettings {
                 play_pause: "CommandOrControl+Shift+Space".into(),
-                next_track: "CommandOrControl+Shift+Right".into(),
-                prev_track: "CommandOrControl+Shift+Left".into(),
+                next_track: "CommandOrControl+Alt+Right".into(),
+                prev_track: "CommandOrControl+Alt+Left".into(),
             },
         }
+    }
+}
+
+pub type SharedSettings = Arc<RwLock<AppSettings>>;
+
+fn settings_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_data_dir()
+        .ok()
+        .map(|dir| dir.join(SETTINGS_FILE))
+}
+
+/// Load settings from disk; fall back to defaults if missing/corrupt. This
+/// is intentionally sync so it can run before the async runtime is spun up.
+pub fn load(app: &AppHandle) -> AppSettings {
+    let Some(path) = settings_path(app) else {
+        return AppSettings::default();
+    };
+    let Ok(bytes) = std::fs::read(&path) else {
+        return AppSettings::default();
+    };
+    match serde_json::from_slice::<AppSettings>(&bytes) {
+        Ok(settings) => settings,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to parse settings.json, using defaults");
+            AppSettings::default()
+        }
+    }
+}
+
+pub fn save(app: &AppHandle, settings: &AppSettings) {
+    let Some(path) = settings_path(app) else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_json::to_vec_pretty(settings) {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(&path, &bytes) {
+                tracing::warn!(error = %e, "failed to write settings.json");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "failed to serialize settings"),
+    }
+}
+
+/// Read a snapshot of the current settings synchronously by briefly
+/// blocking on the Tokio RwLock. Used by window-event handlers that can't
+/// await. The read is short (microseconds) and contention is negligible
+/// since writes only happen when the user flips a toggle.
+pub fn read_blocking(state: &SharedSettings) -> AppSettings {
+    tauri::async_runtime::block_on(async { state.read().await.clone() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_close_to_tray_enabled() {
+        let s = AppSettings::default();
+        assert!(s.general.close_to_tray);
+        assert!(s.general.background_playback);
+        assert!(s.integrations.notifications_enabled);
+    }
+
+    #[test]
+    fn roundtrips_via_json() {
+        let mut s = AppSettings::default();
+        s.general.close_to_tray = false;
+        let bytes = serde_json::to_vec(&s).unwrap();
+        let parsed: AppSettings = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn serializes_with_camel_case_keys() {
+        let s = AppSettings::default();
+        let v = serde_json::to_value(&s).unwrap();
+        assert!(v["general"]["closeToTray"].is_boolean());
+        assert!(v["general"]["backgroundPlayback"].is_boolean());
+        assert!(v["integrations"]["notificationsEnabled"].is_boolean());
     }
 }

--- a/src-tauri/src/webview_bridge/poller.rs
+++ b/src-tauri/src/webview_bridge/poller.rs
@@ -198,10 +198,39 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
             // DOM doesn't exist yet on the sign-in page).
             if let Some(cur) = bs.logged_in {
                 let mut last_li = last_logged_in.lock().await;
-                if *last_li != Some(cur) {
+                let changed = *last_li != Some(cur);
+                if changed {
                     *last_li = Some(cur);
                     drop(last_li);
                     let _ = app.emit("player:login-changed", &cur);
+
+                    // Hard-reset the shared player state on sign-out so the
+                    // next subscriber receives defaults instead of whatever
+                    // was last scrobbled (issue #37). Also drop cached
+                    // account info and re-emit so the sidebar clears.
+                    if !cur {
+                        {
+                            let mut ps = player_state.write().await;
+                            *ps = crate::state::player::PlayerState::default();
+                        }
+                        let mut last_acc = last_account.lock().await;
+                        *last_acc = None;
+                        drop(last_acc);
+                        // null signals "no account" so useAccountInfo clears
+                        // the avatar+name on the sidebar.
+                        let _ =
+                            app.emit("player:account-changed", &serde_json::Value::Null);
+                        // Reset the change-detection caches so the next
+                        // track/status after sign-in re-emits the full truth.
+                        let mut lv = last_video_id.lock().await;
+                        lv.clear();
+                        drop(lv);
+                        let mut ls = last_status.lock().await;
+                        ls.clear();
+                        drop(ls);
+                    }
+                } else {
+                    drop(last_li);
                 }
             }
 
@@ -251,6 +280,23 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                 format!("{}:{}", bs.title, bs.artist)
             };
 
+            // Backfill the initial duration from the side-cache when the
+            // bridge hasn't reported one yet. Prevents a ~1s window where a
+            // freshly-clicked track has duration 0 (so the progress bar looks
+            // pinned at 100%) before YTM's metadata lands.
+            let cached_duration = if !bs.video_id.is_empty() {
+                app.try_state::<crate::cache::Cache>()
+                    .and_then(|c| c.get_track_duration(&bs.video_id))
+                    .unwrap_or(0.0)
+            } else {
+                0.0
+            };
+            let initial_duration = if bs.duration_secs > 0.0 {
+                bs.duration_secs
+            } else {
+                cached_duration
+            };
+
             let mut last_vid = last_video_id.lock().await;
             let track_changed = track_key != *last_vid;
             if track_changed {
@@ -265,7 +311,7 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                     album: bs.album.clone(),
                     album_id: None,
                     artwork_url: if bs.artwork_url.is_empty() { None } else { Some(bs.artwork_url.clone()) },
-                    duration_secs: bs.duration_secs,
+                    duration_secs: initial_duration,
                 };
 
                 // Persist duration in the side-cache so future list responses
@@ -290,13 +336,16 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                 // Same track, but duration may have just become available
                 // (YTM occasionally reports 0 for the first few cycles while
                 // the <video> element buffers). Re-emit so the progress bar
-                // doesn't pin at the end.
+                // doesn't pin at the end. Also accept a *larger* duration —
+                // YTM sometimes reports a partial/buffered length first
+                // (issue #34: a 4:12 track shown as 0:29) before lengthSeconds
+                // resolves. Never shrink once we have a confirmed length.
                 if bs.duration_secs > 0.0 {
                     let needs_update = {
                         let ps = player_state.read().await;
                         ps.track
                             .as_ref()
-                            .map(|t| t.duration_secs <= 0.0)
+                            .map(|t| bs.duration_secs > t.duration_secs + 0.5)
                             .unwrap_or(false)
                     };
                     if needs_update {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { type FC } from 'react';
+import { type FC, memo } from 'react';
 import { useAccountInfo } from '../../hooks/useAccountInfo';
 import { CachedImage } from '../CachedImage';
 
@@ -158,7 +158,19 @@ interface AccountCardProps {
   account: { name: string; avatarUrl: string } | null;
 }
 
-const AccountCard: FC<AccountCardProps> = ({ account }) => (
+// Memo keeps the avatar image stable across parent re-renders triggered by
+// track/position/status events. Without this the <CachedImage> inside would
+// tear down and re-probe on every player event, causing a visible flicker
+// of the profile picture whenever a new song started (issue #38).
+const AccountCard = memo(
+  AccountCardInner,
+  (prev, next) =>
+    prev.account?.name === next.account?.name &&
+    prev.account?.avatarUrl === next.account?.avatarUrl,
+);
+
+function AccountCardInner({ account }: AccountCardProps) {
+  return (
   <div
     style={{
       display: 'flex',
@@ -212,4 +224,5 @@ const AccountCard: FC<AccountCardProps> = ({ account }) => (
       </div>
     </div>
   </div>
-);
+  );
+}

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -1,5 +1,8 @@
-import { type FC, useEffect, useState } from 'react';
-import { cacheApi, ytmApi, type CacheStats } from '../../lib/ipc';
+import { type FC, useEffect, useRef, useState } from 'react';
+import { cacheApi, settingsApi, ytmApi, type AppSettings, type CacheStats } from '../../lib/ipc';
+
+declare const __APP_VERSION__: string;
+const APP_VERSION = __APP_VERSION__;
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -175,18 +178,22 @@ const OutlinedButton: FC<{ label: string; onClick: () => void }> = ({ label, onC
   </button>
 );
 
+// Mirrors the chords registered in
+// src-tauri/src/integrations/global_shortcuts.rs. Keep in sync — otherwise
+// the Settings page advertises bindings that aren't wired up.
 const SHORTCUTS = [
-  { action: 'Play / Pause', keys: 'Space' },
-  { action: 'Next Track', keys: 'Cmd + Right' },
-  { action: 'Previous Track', keys: 'Cmd + Left' },
+  { action: 'Play / Pause', keys: '\u2318 \u21E7 Space' },
+  { action: 'Next Track', keys: '\u2318 \u2325 \u2192' },
+  { action: 'Previous Track', keys: '\u2318 \u2325 \u2190' },
 ] as const;
 
 export const SettingsPage: FC = () => {
-  const [closeToTray, setCloseToTray] = useState(false);
-  const [backgroundPlayback, setBackgroundPlayback] = useState(true);
-  const [desktopNotifications, setDesktopNotifications] = useState(true);
+  const [settings, setSettings] = useState<AppSettings | null>(null);
   const [cacheStats, setCacheStats] = useState<CacheStats | null>(null);
   const [isClearingCache, setIsClearingCache] = useState(false);
+  // Suppress the first save: we receive the persisted state from the
+  // backend and would otherwise immediately round-trip it right back.
+  const hydratedRef = useRef(false);
 
   const loadCacheStats = () => {
     cacheApi
@@ -197,7 +204,37 @@ export const SettingsPage: FC = () => {
 
   useEffect(() => {
     loadCacheStats();
+    settingsApi
+      .get()
+      .then(setSettings)
+      .catch((e) => console.error('settings load failed', e));
   }, []);
+
+  useEffect(() => {
+    if (!settings) return;
+    if (!hydratedRef.current) {
+      // The first settings value came from disk — skip the save so we
+      // don't immediately round-trip the same bytes back.
+      hydratedRef.current = true;
+      return;
+    }
+    settingsApi.set(settings).catch((e) => console.error('settings save failed', e));
+  }, [settings]);
+
+  const updateGeneral = (patch: Partial<AppSettings['general']>) => {
+    setSettings((prev) =>
+      prev ? { ...prev, general: { ...prev.general, ...patch } } : prev,
+    );
+  };
+  const updateIntegrations = (patch: Partial<AppSettings['integrations']>) => {
+    setSettings((prev) =>
+      prev ? { ...prev, integrations: { ...prev.integrations, ...patch } } : prev,
+    );
+  };
+
+  const closeToTray = settings?.general.closeToTray ?? true;
+  const backgroundPlayback = settings?.general.backgroundPlayback ?? true;
+  const desktopNotifications = settings?.integrations.notificationsEnabled ?? true;
 
   const handleClearCache = async () => {
     setIsClearingCache(true);
@@ -234,11 +271,19 @@ export const SettingsPage: FC = () => {
       <SectionHeading title="General" />
       <Divider />
       <SettingRow label="Close to tray" description="Keep VibeYTM running in the menu bar when the window is closed">
-        <ToggleSwitch checked={closeToTray} onChange={setCloseToTray} />
+        <ToggleSwitch
+          checked={closeToTray}
+          disabled={!settings}
+          onChange={(v) => updateGeneral({ closeToTray: v })}
+        />
       </SettingRow>
       <Divider />
       <SettingRow label="Background playback" description="Continue playing audio when the app is in the background">
-        <ToggleSwitch checked={backgroundPlayback} onChange={setBackgroundPlayback} />
+        <ToggleSwitch
+          checked={backgroundPlayback}
+          disabled={!settings}
+          onChange={(v) => updateGeneral({ backgroundPlayback: v })}
+        />
       </SettingRow>
       <Divider />
 
@@ -246,7 +291,11 @@ export const SettingsPage: FC = () => {
       <SectionHeading title="Integrations" />
       <Divider />
       <SettingRow label="Desktop notifications" description="Show notifications when the track changes">
-        <ToggleSwitch checked={desktopNotifications} onChange={setDesktopNotifications} />
+        <ToggleSwitch
+          checked={desktopNotifications}
+          disabled={!settings}
+          onChange={(v) => updateIntegrations({ notificationsEnabled: v })}
+        />
       </SettingRow>
       <Divider />
 
@@ -325,7 +374,7 @@ export const SettingsPage: FC = () => {
             marginBottom: 'var(--space-2)',
           }}
         >
-          VibeYTM v0.1.0
+          VibeYTM v{APP_VERSION}
         </div>
         <div
           style={{

--- a/src/hooks/useAccountInfo.ts
+++ b/src/hooks/useAccountInfo.ts
@@ -21,7 +21,9 @@ export function useAccountInfo(): AccountInfo | null {
     };
   }, []);
 
-  useTauriEvent<AccountInfo>('player:account-changed', (info) => {
+  useTauriEvent<AccountInfo | null>('player:account-changed', (info) => {
+    // Null payload means "signed out" — clear the sidebar avatar and name
+    // so stale info doesn't linger after the user logs out (issue #37).
     setAccount(info);
   });
 

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -5,9 +5,15 @@ import { EVENTS } from '../lib/events';
 import { useTauriEvent } from './useTauriEvent';
 
 // Drop VOLUME_CHANGED echoes that arrive within this window of a local
-// optimistic set, so fast drags aren't overwritten by stale intermediate
-// values from the YTM bridge poller.
-const VOLUME_ECHO_WINDOW_MS = 500;
+// optimistic set, so fast drags (and click-to-jump) aren't overwritten by
+// stale intermediate values from the YTM bridge poller. The bridge polls at
+// 150ms and YTM's <video>.volume can take up to 3 poll cycles to settle, so
+// 1200ms absorbs the whole settling window.
+const VOLUME_ECHO_WINDOW_MS = 1200;
+
+// After a seek, ignore STATUS_CHANGED=paused events for this long — they
+// are usually stale echoes from before YTM resumed (issue #41).
+const SEEK_STATUS_ECHO_WINDOW_MS = 800;
 
 // After a manual seek, POSITION_UPDATED events emitted before YTM finished
 // seeking carry pre-seek timestamps that would visually bounce the thumb
@@ -53,6 +59,10 @@ export function usePlayerState(): UsePlayerState {
   const lastSeekAtRef = useRef(0);
   const seekTargetRef = useRef(0);
   const lastTrackChangeAtRef = useRef(0);
+  // Latest status mirror so event handlers can branch on it without
+  // rebinding every render. Kept in sync with state.status below.
+  const statusRef = useRef<PlaybackStatus>(DEFAULT_STATE.status);
+  statusRef.current = state.status;
 
   useEffect(() => {
     playerApi.getState().then((s) => {
@@ -72,6 +82,18 @@ export function usePlayerState(): UsePlayerState {
   });
 
   useTauriEvent<PlaybackStatus>(EVENTS.STATUS_CHANGED, (status) => {
+    // Suppress stale "paused" echoes right after a seek: YTM briefly
+    // reports paused while the video element reseats the buffer, and the
+    // play button would flicker to paused before the next "playing" event
+    // caught up (issue #41). Drop paused events inside the echo window
+    // while we still believe we're playing.
+    if (
+      status === 'paused' &&
+      statusRef.current === 'playing' &&
+      Date.now() - lastSeekAtRef.current < SEEK_STATUS_ECHO_WINDOW_MS
+    ) {
+      return;
+    }
     setState((prev) => ({ ...prev, status }));
   });
 
@@ -128,6 +150,17 @@ export function usePlayerState(): UsePlayerState {
 
   useTauriEvent<boolean>(EVENTS.LIKE_CHANGED, (isLiked) => {
     setState((prev) => ({ ...prev, isLiked }));
+  });
+
+  // When the user signs out of YouTube Music, the player controller bar
+  // still shows the last track's metadata until the page is reloaded
+  // (issue #37). Reset the entire player slice to defaults so the sidebar
+  // and bottom bar return to their idle state. Account info is handled
+  // separately via useAccountInfo.
+  useTauriEvent<boolean>(EVENTS.LOGIN_CHANGED, (loggedIn) => {
+    if (!loggedIn) {
+      setState(DEFAULT_STATE);
+    }
   });
 
   const applyOptimistic = useCallback((patch: Partial<PlayerState>) => {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -7,4 +7,6 @@ export const EVENTS = {
   SHUFFLE_CHANGED: 'player:shuffle-changed',
   REPEAT_CHANGED: 'player:repeat-changed',
   LIKE_CHANGED: 'player:like-changed',
+  LOGIN_CHANGED: 'player:login-changed',
+  ACCOUNT_CHANGED: 'player:account-changed',
 } as const;

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -44,6 +44,26 @@ export const ytmApi = {
   injectBridge: () => invoke('inject_ytm_bridge'),
 };
 
+export interface AppSettings {
+  general: {
+    closeToTray: boolean;
+    backgroundPlayback: boolean;
+  };
+  integrations: {
+    notificationsEnabled: boolean;
+  };
+  shortcuts: {
+    playPause: string;
+    nextTrack: string;
+    prevTrack: string;
+  };
+}
+
+export const settingsApi = {
+  get: () => invoke<AppSettings>('get_settings'),
+  set: (settings: AppSettings) => invoke<void>('set_settings', { new: settings }),
+};
+
 export const browseApi = {
   search: (query: string, filter?: string) => invoke<SearchResults>('search', { query, filter: filter ?? null }),
   searchSuggestions: (query: string) => invoke<string[]>('search_suggestions', { query }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import pkg from "./package.json" with { type: "json" };
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -7,6 +8,9 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
## Summary

Closes 10 oldest open issues (#34–#43, skipping #24) and bumps the version to 0.6.0.

| # | Fix |
|---|---|
| #34 | Prefer `getVideoData().lengthSeconds`; never shrink duration once known |
| #35 | Update Settings shortcut display to match real chords (⌘⇧Space / ⌘⌥→ / ⌘⌥←) |
| #36 / #42 | Extend volume echo window to 1200 ms so YTM settling can't bounce the slider |
| #37 | Reset player state + clear sidebar account on sign-out |
| #38 | Memoize AccountCard so track events don't flicker the sidebar avatar |
| #39 | Prefer the expanded "song image" over the player-bar video thumbnail |
| #40 | Bridge watchdog nudges playback if a track stalls at 0:00 for 4 s |
| #41 | Suppress stale "paused" status events within 800 ms of a seek |
| #43 | Persist app settings; wire "Close to tray" toggle to window close handler |

Bonus: Settings → About now reads the live `__APP_VERSION__` from `package.json`, fixing the latent #45 stale version label.

## Test plan
- [x] `pnpm typecheck`
- [x] `cargo test --lib` (54 / 54 pass)
- [x] `pnpm build`
- [x] `pnpm tauri build` produces `VibeYTM_0.6.0_aarch64.dmg`
- [ ] Smoke run the DMG locally and tick the "Regression Checklist for 0.6.0" in `TEST_CHECKLIST.md`