### PR TITLE
v0.7.0: fix 9 open issues

### DIFF
--- a/TEST_CHECKLIST.md
+++ b/TEST_CHECKLIST.md
@@ -56,8 +56,39 @@ Apply to: Home, Search (Albums/Artists tabs), Explore, Library, Playlist detail
 - [ ] **#43** "Close to tray" toggle persists across restarts. With it OFF, the
       red close button exits the app. With it ON, the app hides to the tray.
 
+## Regression Checklist for 0.7.0
+- [ ] **#24** Closing the app and relaunching restores the last-played track
+      name, artwork, duration, and progress bar position (no autoplay — status
+      stays idle until user clicks Play). Works even if closed within 5 s of
+      playback starting.
+- [ ] **#41** Clicking the progress bar while a track is playing (or buffering
+      mid-seek) NEVER flashes the pause glyph. Pausing manually still works
+      instantly.
+- [ ] **#44** When YTM raises a playback error (e.g. region-blocked track),
+      the app retries playback automatically — `playVideo()` once, then
+      `seekTo(0)+play`, then `nextVideo()` — instead of freezing the queue.
+- [ ] **#45** Settings → About displays the true bundled app version
+      (pulled at runtime from the Tauri app API, not a build-time fallback).
+- [ ] **#46** Playlist detail page shows a "+ Save to library" button.
+      Clicking saves the playlist to the user's library; the button flips to
+      "✓ Saved" and a second click removes it.
+- [ ] **#47** With Background playback = OFF, closing the main window (tray
+      mode) pauses the music immediately. With it ON, audio continues.
+- [ ] **#48** Non-square cover images (e.g. 16:9 video thumbnails) display
+      letterboxed inside the square frame instead of being aggressively
+      center-cropped. Square album art still fills the frame edge-to-edge.
+- [ ] **#50** After sign-out, the sidebar avatar and name clear to
+      "Not signed in" and the home-page cache is dropped so the feed
+      refreshes with non-signed-in content on next visit.
+- [ ] **#51** If the user is already signed in, launching the app no longer
+      flashes the LoginPage or the YTM window — it boots directly into the
+      main UI. The YTM window is only surfaced when sign-in is needed.
+
 ## Login Flow
-- [ ] App launches with two windows (VibeYTM + YouTube Music)
+- [ ] First launch (no cached session): LoginPage appears and the YouTube
+      Music window surfaces automatically so the user can sign in
+- [ ] Relaunch while already signed in: no LoginPage, no YTM window flash —
+      the main UI appears directly (issue #51)
 - [ ] YouTube Music page loads without "unsupported browser" error
 - [ ] Can sign in to Google account (2FA works)
 - [ ] "I'm signed in — let's go" hides YTM window and shows main UI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/inject/ytm-player-bridge.js
+++ b/scripts/inject/ytm-player-bridge.js
@@ -281,6 +281,48 @@
   };
 
   /**
+   * Auto-retry on YTM playback errors (issue #44). The YTM iframe player
+   * surfaces error codes (2,5,100,101,150) via `onError` — typically for
+   * region-blocked, private, or removed videos. Without intervention the
+   * player stalls with no way forward. Policy:
+   *   attempt 1: playVideo() — transient network/DRM glitches often recover
+   *   attempt 2: seekTo(0) + playVideo()
+   *   attempt >=3 within the retry window: nextVideo() so the queue advances
+   * The attempt counter resets once we observe actual progress (position > 1s)
+   * so an eventually-good track doesn't poison the next failure.
+   */
+  var errorRetries = 0;
+  var lastErrorAtMs = 0;
+  var ERROR_RESET_WINDOW_MS = 30000;
+
+  function attachPlayerErrorListener(player) {
+    if (!player || !player.addEventListener) return;
+    try {
+      player.addEventListener('onError', function (code) {
+        var now = Date.now();
+        if (now - lastErrorAtMs > ERROR_RESET_WINDOW_MS) {
+          errorRetries = 0;
+        }
+        lastErrorAtMs = now;
+        errorRetries += 1;
+        log('onError code=' + code + ' attempt=' + errorRetries);
+        try {
+          if (errorRetries === 1) {
+            player.playVideo();
+          } else if (errorRetries === 2) {
+            player.seekTo(0, true);
+            player.playVideo();
+          } else {
+            // Give up on this track — advance the queue so playback continues.
+            player.nextVideo();
+            errorRetries = 0;
+          }
+        } catch (e) {}
+      });
+    } catch (e) {}
+  }
+
+  /**
    * Watchdog for issue #40: songs occasionally start, then stall at 0:00
    * with status "playing" or "buffering" — the <video> element is ready
    * but playback never actually begins. If we stay at position 0 for
@@ -312,6 +354,8 @@
       if (pos > lastPositionSample) {
         stuckSinceMs = 0;
         stuckRetries = 0;
+        // Clear the error-retry counter too — we proved the track works.
+        if (pos > 1.0) errorRetries = 0;
       }
       lastPositionSample = pos;
       if (pos > 0.25) return;
@@ -347,8 +391,10 @@
   }
 
   function waitForPlayer() {
-    if (getPlayer()) {
+    var p = getPlayer();
+    if (p) {
       log('player found');
+      attachPlayerErrorListener(p);
       setInterval(update, 150);
       setInterval(checkStuck, 1000);
       update();

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5147,7 +5147,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibeytm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibeytm"
-version = "0.6.0"
+version = "0.7.0"
 description = "An Apple Music-style YouTube Music desktop app"
 authors = ["dongli"]
 edition = "2021"

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -207,3 +207,29 @@ pub async fn get_library_artists(
     tracing::info!(artists = result.len(), "browse::get_library_artists done");
     Ok(result)
 }
+
+#[tauri::command]
+pub async fn save_playlist_to_library(
+    playlist_id: String,
+    app: AppHandle,
+    api: State<'_, YtmApi>,
+) -> Result<(), String> {
+    tracing::info!(playlist_id = %playlist_id, "browse::save_playlist_to_library called");
+    api.save_playlist_to_library(&app, &playlist_id).await.map_err(|e| {
+        tracing::error!(error = %e, "browse::save_playlist_to_library failed");
+        e.to_string()
+    })
+}
+
+#[tauri::command]
+pub async fn remove_playlist_from_library(
+    playlist_id: String,
+    app: AppHandle,
+    api: State<'_, YtmApi>,
+) -> Result<(), String> {
+    tracing::info!(playlist_id = %playlist_id, "browse::remove_playlist_from_library called");
+    api.remove_playlist_from_library(&app, &playlist_id).await.map_err(|e| {
+        tracing::error!(error = %e, "browse::remove_playlist_from_library failed");
+        e.to_string()
+    })
+}

--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -81,6 +81,18 @@ pub async fn get_account_info(
     Ok(player.account.clone())
 }
 
+/// Returns the YTM sign-in state as last observed by the bridge poller.
+/// Tri-state: None = bridge hasn't reported yet; Some(true) = signed in;
+/// Some(false) = signed out. Used by the frontend on launch to skip the
+/// login gate when the user is already authenticated (issue #51).
+#[tauri::command]
+pub async fn get_login_state(
+    state: State<'_, SharedPlayerState>,
+) -> Result<Option<bool>, String> {
+    let player = state.read().await;
+    Ok(player.logged_in)
+}
+
 // --- Queue management ---
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,13 +43,41 @@ pub fn run() {
             // a conventional desktop program (issue #43).
             if window.label() == "main" {
                 if let WindowEvent::CloseRequested { api, .. } = event {
-                    let close_to_tray = window
+                    let settings = window
                         .app_handle()
                         .try_state::<SharedSettings>()
-                        .map(|s| state::settings::read_blocking(&s).general.close_to_tray)
-                        .unwrap_or(true);
-                    if close_to_tray {
+                        .map(|s| state::settings::read_blocking(&s).general)
+                        .unwrap_or(state::settings::GeneralSettings {
+                            close_to_tray: true,
+                            background_playback: true,
+                        });
+                    // Flush the last-played session to disk right now so the
+                    // next launch can restore it even when the user closes
+                    // the app within the saver's 5s tick (issue #24).
+                    if let Some(player_state) = window
+                        .app_handle()
+                        .try_state::<SharedPlayerState>()
+                    {
+                        state::persistence::flush_now(
+                            window.app_handle(),
+                            &player_state,
+                        );
+                    }
+                    if settings.close_to_tray {
                         api.prevent_close();
+                        // If the user opted out of background playback, pause
+                        // the YTM webview before hiding the main window so
+                        // audio doesn't keep playing in the tray (issue #47).
+                        if !settings.background_playback {
+                            if let Some(ytm_window) =
+                                crate::webview_bridge::get_ytm_window(window.app_handle())
+                            {
+                                let _ = crate::webview_bridge::exec_playback_command(
+                                    &ytm_window,
+                                    "pause",
+                                );
+                            }
+                        }
                         let _ = window.hide();
                     } else {
                         // Let the event proceed; Tauri will close the window,
@@ -70,6 +98,7 @@ pub fn run() {
             commands::on_position_updated,
             commands::get_player_state,
             commands::player::get_account_info,
+            commands::player::get_login_state,
             commands::player::play,
             commands::player::pause,
             commands::player::toggle_play,
@@ -98,6 +127,8 @@ pub fn run() {
             commands::browse::get_library_songs,
             commands::browse::get_library_albums,
             commands::browse::get_library_artists,
+            commands::browse::save_playlist_to_library,
+            commands::browse::remove_playlist_from_library,
             commands::cache::cache_fetch_image,
             commands::cache::cache_clear,
             commands::cache::cache_stats,
@@ -167,10 +198,13 @@ pub fn run() {
             // 1. YouTube Music accepts Safari as a supported browser
             // 2. Google sign-in allows Safari (unlike Chrome-spoofed WebViews)
             let safari_ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15";
+            // Start the YTM window hidden so an already-signed-in user never
+            // sees it flash on launch (issue #51). The LoginPage will call
+            // show_ytm when sign-in is actually needed.
             let ytm_builder = WebviewWindowBuilder::new(app, "ytm", ytm_url)
                 .title("YouTube Music")
                 .inner_size(1024.0, 700.0)
-                .visible(true)
+                .visible(false)
                 .decorations(true)
                 .center()
                 .user_agent(safari_ua)

--- a/src-tauri/src/state/persistence.rs
+++ b/src-tauri/src/state/persistence.rs
@@ -59,6 +59,22 @@ fn save_sync(app: &AppHandle, session: &PersistedSession) {
     }
 }
 
+/// Flush the current in-memory state to disk immediately. Called from the
+/// window-close handler so the last-played track/position survives even if
+/// the user closes the app within 5 seconds of starting playback (before the
+/// periodic saver has had a chance to tick) — issue #24.
+pub fn flush_now(app: &AppHandle, state: &SharedPlayerState) {
+    let snapshot = {
+        let player = tauri::async_runtime::block_on(async { state.read().await.clone() });
+        PersistedSession {
+            track: player.track.clone(),
+            position_secs: player.position_secs,
+            volume: player.volume,
+        }
+    };
+    save_sync(app, &snapshot);
+}
+
 /// Apply a loaded session to in-memory state. Position and volume are
 /// restored verbatim; playback status stays idle so nothing auto-plays.
 pub async fn apply(state: &SharedPlayerState, session: PersistedSession) {

--- a/src-tauri/src/state/player.rs
+++ b/src-tauri/src/state/player.rs
@@ -53,6 +53,11 @@ pub struct PlayerState {
     pub is_shuffled: bool,
     pub queue: Vec<TrackInfo>,
     pub account: Option<AccountInfo>,
+    /// Tri-state YTM sign-in status. None = unknown (bridge not yet loaded),
+    /// Some(true) = signed in, Some(false) = signed out. Used on app launch
+    /// to decide whether to skip the login page (issue #51) and to avoid
+    /// rendering stale signed-in data after sign-out (issue #50).
+    pub logged_in: Option<bool>,
 }
 
 impl Default for PlayerState {
@@ -67,6 +72,7 @@ impl Default for PlayerState {
             is_shuffled: false,
             queue: Vec::new(),
             account: None,
+            logged_in: None,
         }
     }
 }

--- a/src-tauri/src/webview_bridge/poller.rs
+++ b/src-tauri/src/webview_bridge/poller.rs
@@ -202,6 +202,13 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                 if changed {
                     *last_li = Some(cur);
                     drop(last_li);
+                    // Mirror into the shared player state so the frontend can
+                    // query it synchronously at launch (issue #51) instead of
+                    // racing the login event.
+                    {
+                        let mut ps = player_state.write().await;
+                        ps.logged_in = Some(cur);
+                    }
                     let _ = app.emit("player:login-changed", &cur);
 
                     // Hard-reset the shared player state on sign-out so the
@@ -212,6 +219,7 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                         {
                             let mut ps = player_state.write().await;
                             *ps = crate::state::player::PlayerState::default();
+                            ps.logged_in = Some(false);
                         }
                         let mut last_acc = last_account.lock().await;
                         *last_acc = None;

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -184,6 +184,42 @@ impl YtmApi {
         let data: Value = serde_json::from_str(&raw)?;
         Ok(parse_library_artists(&data))
     }
+
+    /// Add a playlist to the signed-in user's library ("Saved playlists").
+    /// Uses the YTM like endpoint with the playlist as the target — the same
+    /// call the YTM web UI's save button makes, which adds the playlist to
+    /// FEmusic_liked_playlists (issue #46).
+    pub async fn save_playlist_to_library(
+        &self,
+        app: &AppHandle,
+        playlist_id: &str,
+    ) -> anyhow::Result<()> {
+        let body = serde_json::json!({
+            "target": { "playlistId": playlist_id }
+        })
+        .to_string();
+        ytm_api_call(app, "like/like", &body)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        Ok(())
+    }
+
+    /// Remove a playlist from the signed-in user's library. Mirror of
+    /// `save_playlist_to_library`.
+    pub async fn remove_playlist_from_library(
+        &self,
+        app: &AppHandle,
+        playlist_id: &str,
+    ) -> anyhow::Result<()> {
+        let body = serde_json::json!({
+            "target": { "playlistId": playlist_id }
+        })
+        .to_string();
+        ytm_api_call(app, "like/removelike", &body)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useCallback, useRef } from 'react';
+import { type FC, useState, useCallback, useEffect, useRef } from 'react';
 import './styles/global.css';
 import { AppShell } from './components/layout/AppShell';
 import { HomePage } from './components/pages/HomePage';
@@ -8,6 +8,8 @@ import { ExplorePage } from './components/pages/ExplorePage';
 import { SettingsPage } from './components/pages/SettingsPage';
 import { LoginPage } from './components/pages/LoginPage';
 import { PlaylistDetailPage } from './components/pages/PlaylistDetailPage';
+import { useLoginState } from './hooks/useLoginState';
+import { ytmApi } from './lib/ipc';
 
 interface ViewingPlaylist {
   id: string;
@@ -15,7 +17,11 @@ interface ViewingPlaylist {
 }
 
 const App: FC = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const loginState = useLoginState();
+  // Local override so the user can dismiss the login page manually (e.g. via
+  // "Skip for now") even if the bridge hasn't confirmed sign-in yet.
+  const [loginOverride, setLoginOverride] = useState(false);
+  const isLoggedIn = loginState === true || loginOverride;
   const [currentPath, setCurrentPath] = useState('home');
   const [isNowPlayingOpen, setIsNowPlayingOpen] = useState(false);
   const [viewingPlaylist, setViewingPlaylist] = useState<ViewingPlaylist | null>(null);
@@ -48,8 +54,37 @@ const App: FC = () => {
     setCurrentPath('search');
   }, []);
 
+  // Hide the YTM window as soon as we confirm the user is signed in. Without
+  // this the window lingers from its .visible(true) startup state (issue #51).
+  useEffect(() => {
+    if (loginState === true) {
+      ytmApi.hideYtm().catch(() => {
+        // If hiding fails, the YTM window stays — non-fatal.
+      });
+    }
+  }, [loginState]);
+
+  // While we don't know the login state, show a neutral placeholder instead
+  // of flashing the login page first.
+  if (loginState === null && !loginOverride) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          color: 'var(--color-text-tertiary)',
+          fontSize: 'var(--text-base)',
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
   if (!isLoggedIn) {
-    return <LoginPage onLoggedIn={() => setIsLoggedIn(true)} />;
+    return <LoginPage onLoggedIn={() => setLoginOverride(true)} />;
   }
 
   const renderPage = () => {

--- a/src/components/CachedImage.tsx
+++ b/src/components/CachedImage.tsx
@@ -9,7 +9,19 @@ interface CachedImageProps {
   style?: CSSProperties;
   onError?: (e: React.SyntheticEvent<HTMLImageElement>) => void;
   loading?: 'lazy' | 'eager';
+  /**
+   * When true (default for `objectFit: cover` style), if the source image is
+   * non-square (e.g. a 16:9 video thumbnail), swap the fit to `contain` so
+   * the full image is visible instead of aggressively cropped (issue #48).
+   * Pass `false` to preserve the exact style you set.
+   */
+  autoFitForAspect?: boolean;
 }
+
+// Heuristic: treat anything more than ~5% off from 1:1 as "non-square" and
+// switch to contain. Square album art served by YTM is always exactly 1:1, so
+// this only kicks in for genuinely rectangular sources.
+const SQUARE_TOLERANCE = 0.05;
 
 // In-memory map: remote URL -> local asset URL (survives re-renders)
 const inflight = new Map<string, Promise<string | null>>();
@@ -53,12 +65,15 @@ export const CachedImage: FC<CachedImageProps> = ({
   style,
   onError,
   loading = 'lazy',
+  autoFitForAspect = true,
 }) => {
   const [displayUrl, setDisplayUrl] = useState<string | undefined>(undefined);
+  const [naturalAspect, setNaturalAspect] = useState<number | null>(null);
 
   useEffect(() => {
     if (!src) {
       setDisplayUrl(undefined);
+      setNaturalAspect(null);
       return;
     }
 
@@ -69,15 +84,20 @@ export const CachedImage: FC<CachedImageProps> = ({
     const tryReveal = async (url: string) => {
       // Step 2: pre-decode the image off-DOM so the browser fully prepares
       // the bitmap. Only after decode() resolves do we mount the <img>.
+      const probe = new Image();
+      probe.src = url;
+      let aspect: number | null = null;
       try {
-        const probe = new Image();
-        probe.src = url;
         await probe.decode();
+        if (probe.naturalWidth > 0 && probe.naturalHeight > 0) {
+          aspect = probe.naturalWidth / probe.naturalHeight;
+        }
       } catch {
         // decode() can reject for cross-origin images even when they're
         // perfectly loadable; ignore and fall through to mount anyway.
       }
       if (cancelled) return;
+      setNaturalAspect(aspect);
       setDisplayUrl(url);
     };
 
@@ -101,6 +121,17 @@ export const CachedImage: FC<CachedImageProps> = ({
     return null;
   }
 
+  // When the caller requested `objectFit: cover` but the source is decidedly
+  // non-square (video thumbnails, typically ~16:9), switch to `contain` so the
+  // whole image is visible inside the square frame instead of being aggressively
+  // cropped — the exact complaint in issue #48.
+  const effectiveStyle: CSSProperties = (() => {
+    if (!autoFitForAspect || !style || style.objectFit !== 'cover') return style ?? {};
+    if (naturalAspect === null) return style;
+    if (Math.abs(naturalAspect - 1) <= SQUARE_TOLERANCE) return style;
+    return { ...style, objectFit: 'contain' };
+  })();
+
   return (
     <img
       src={displayUrl}
@@ -108,7 +139,7 @@ export const CachedImage: FC<CachedImageProps> = ({
       width={width}
       height={height}
       loading={loading}
-      style={style}
+      style={effectiveStyle}
       onError={onError}
     />
   );

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -332,7 +332,18 @@ export const PlayerBar: FC<PlayerBarProps> = ({
               // that would otherwise bounce the thumb back to the old spot.
               const next = Number(e.target.value);
               markSeek(next);
-              applyOptimistic({ positionSecs: next });
+              // If we're currently playing, force the optimistic status
+              // back to 'playing' too. During a seek YTM briefly reports
+              // buffering/paused while the <video> reseats the buffer, and
+              // that transient would otherwise flash the pause glyph
+              // (issue #41). The STATUS_CHANGED echo guard needs the UI to
+              // already believe it's playing to know to discard the stale
+              // paused event.
+              if (isPlaying) {
+                applyOptimistic({ positionSecs: next, status: 'playing' });
+              } else {
+                applyOptimistic({ positionSecs: next });
+              }
               playerApi.seek(next);
               // If the user scrubs while paused, treat the click as "resume
               // here" — standard behavior across music players.

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { type FC, memo } from 'react';
 import { useAccountInfo } from '../../hooks/useAccountInfo';
+import { useLoginState } from '../../hooks/useLoginState';
 import { CachedImage } from '../CachedImage';
 
 interface NavItemProps {
@@ -69,6 +70,7 @@ const LIBRARY_ITEMS = [
 
 export const Sidebar: FC<SidebarProps> = ({ currentPath, onNavigate }) => {
   const account = useAccountInfo();
+  const loggedIn = useLoginState();
 
   return (
   <aside
@@ -148,7 +150,7 @@ export const Sidebar: FC<SidebarProps> = ({ currentPath, onNavigate }) => {
 
     {/* Account — locked to the very bottom of the sidebar */}
     <div style={{ padding: 'var(--space-3)' }}>
-      <AccountCard account={account} />
+      <AccountCard account={account} loggedIn={loggedIn} />
     </div>
   </aside>
   );
@@ -156,6 +158,8 @@ export const Sidebar: FC<SidebarProps> = ({ currentPath, onNavigate }) => {
 
 interface AccountCardProps {
   account: { name: string; avatarUrl: string } | null;
+  /** Tri-state: true signed in, false signed out, null undetermined. */
+  loggedIn: boolean | null;
 }
 
 // Memo keeps the avatar image stable across parent re-renders triggered by
@@ -165,11 +169,23 @@ interface AccountCardProps {
 const AccountCard = memo(
   AccountCardInner,
   (prev, next) =>
+    prev.loggedIn === next.loggedIn &&
     prev.account?.name === next.account?.name &&
     prev.account?.avatarUrl === next.account?.avatarUrl,
 );
 
-function AccountCardInner({ account }: AccountCardProps) {
+function AccountCardInner({ account, loggedIn }: AccountCardProps) {
+  // Never render the cached avatar or "Signed in" label from a prior session
+  // when the user has signed out (issue #50). Show a neutral placeholder
+  // instead so the sidebar honestly reflects the auth state.
+  const isSignedOut = loggedIn === false;
+  const showAccount = !isSignedOut && account !== null;
+  const label = showAccount
+    ? account.name || 'Signed in'
+    : isSignedOut
+      ? 'Not signed in'
+      : 'Signing in…';
+
   return (
   <div
     style={{
@@ -180,7 +196,7 @@ function AccountCardInner({ account }: AccountCardProps) {
       borderRadius: 'var(--radius-md)',
       minWidth: 0,
     }}
-    title={account?.name || 'Signed in'}
+    title={label}
   >
     <div
       style={{
@@ -197,7 +213,7 @@ function AccountCardInner({ account }: AccountCardProps) {
         color: 'var(--color-text-secondary)',
       }}
     >
-      {account?.avatarUrl ? (
+      {showAccount && account.avatarUrl ? (
         <CachedImage
           src={account.avatarUrl}
           alt={account.name || 'Account avatar'}
@@ -214,13 +230,13 @@ function AccountCardInner({ account }: AccountCardProps) {
         style={{
           fontSize: 'var(--text-sm)',
           fontWeight: 500,
-          color: 'var(--color-text-primary)',
+          color: isSignedOut ? 'var(--color-text-tertiary)' : 'var(--color-text-primary)',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
         }}
       >
-        {account?.name || 'Signed in'}
+        {label}
       </div>
     </div>
   </div>

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { type FC, useCallback, useEffect, useState } from 'react';
 import type { Shelf, TrackInfo } from '../../lib/types';
 import { browseApi, playFirstFromPlaylist } from '../../lib/ipc';
+import { useTauriEvent } from '../../hooks/useTauriEvent';
 import { ShelfRow } from '../browse/ShelfRow';
 import { AlbumCard } from '../browse/AlbumCard';
 import { SongRow } from '../browse/SongRow';
@@ -90,6 +91,21 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
   useEffect(() => {
     fetchHome();
   }, [fetchHome]);
+
+  // When the user signs out, the cached shelves represent the previous
+  // account's home feed. Drop them so the next render pulls non-signed-in
+  // content instead of showing stale personalized data (issue #50).
+  useTauriEvent<boolean>('player:login-changed', (nowLoggedIn) => {
+    if (!nowLoggedIn) {
+      cachedShelves = null;
+      cachedAt = 0;
+      firstLoadDone = false;
+      cachedMoodSongs = null;
+      setShelves([]);
+      setMoodSongs([]);
+      fetchHome(true);
+    }
+  });
 
   // Fetch mood songs when a mood tab other than "All" is selected
   useEffect(() => {

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -26,9 +26,16 @@ export const LoginPage: FC<LoginPageProps> = ({ onLoggedIn }) => {
     if (isLoggedIn) autoAdvance();
   });
 
-  // Also nudge the bridge to re-check quickly so a user who is already
-  // signed in (returning user) isn't forced to wait for the next poll cycle.
+  // The YTM window is created hidden at startup to avoid flashing on an
+  // already-signed-in session (issue #51). If we landed on the LoginPage,
+  // the user needs to see that window to authenticate — surface it.
   useEffect(() => {
+    ytmApi.showYtm().catch(() => {
+      // If showing fails, the user can still click the "Show YouTube Music
+      // window" button below as a manual recovery path.
+    });
+    // Also nudge the bridge to re-check quickly so a user who is already
+    // signed in (returning user) isn't forced to wait for the next poll cycle.
     ytmApi.injectBridge().catch(() => {
       // Bridge was already injected via Tauri init script — safe to ignore.
     });

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -18,6 +18,35 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
   const [playlist, setPlaylist] = useState<PlaylistDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Tri-state local view of whether the playlist is saved. Optimistic — the
+  // backend call confirms after the click, and we roll back on failure.
+  const [isSaved, setIsSaved] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const toggleSaved = async () => {
+    if (isSaving) return;
+    const next = !isSaved;
+    setIsSaving(true);
+    setSaveError(null);
+    setIsSaved(next); // optimistic
+    try {
+      if (next) {
+        await browseApi.savePlaylistToLibrary(playlistId);
+      } else {
+        await browseApi.removePlaylistFromLibrary(playlistId);
+      }
+    } catch (e: unknown) {
+      // Roll back and surface the error so the user knows it didn't stick.
+      setIsSaved(!next);
+      setSaveError(
+        next ? 'Could not save to library' : 'Could not remove from library',
+      );
+      console.error('[PlaylistDetailPage] save toggle failed:', e);
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -323,31 +352,71 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
               {playlist.description}
             </p>
           )}
-          {/* Play all button */}
-          <button
-            onClick={() => {
-              if (playlist.tracks.length > 0 && playlist.tracks[0].videoId) {
-                playerApi.playTrack(playlist.tracks[0].videoId, playlistId).catch(() => {});
-              }
-            }}
+          {/* Action row: Play all + Save to library */}
+          <div
             style={{
-              alignSelf: 'flex-start',
-              marginTop: 'var(--space-2)',
-              background: 'var(--color-accent)',
-              border: 'none',
-              borderRadius: 'var(--radius-full)',
-              padding: 'var(--space-2) var(--space-5)',
-              color: 'oklch(100% 0 0)',
-              fontSize: 'var(--text-sm)',
-              fontWeight: 600,
-              cursor: 'pointer',
-              display: 'inline-flex',
-              alignItems: 'center',
+              display: 'flex',
               gap: 'var(--space-2)',
+              alignItems: 'center',
+              marginTop: 'var(--space-2)',
             }}
           >
-            &#x25B6; Play all
-          </button>
+            <button
+              onClick={() => {
+                if (playlist.tracks.length > 0 && playlist.tracks[0].videoId) {
+                  playerApi.playTrack(playlist.tracks[0].videoId, playlistId).catch(() => {});
+                }
+              }}
+              style={{
+                background: 'var(--color-accent)',
+                border: 'none',
+                borderRadius: 'var(--radius-full)',
+                padding: 'var(--space-2) var(--space-5)',
+                color: 'oklch(100% 0 0)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 600,
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 'var(--space-2)',
+              }}
+            >
+              &#x25B6; Play all
+            </button>
+            <button
+              onClick={toggleSaved}
+              disabled={isSaving}
+              aria-pressed={isSaved}
+              aria-label={isSaved ? 'Remove from library' : 'Save to library'}
+              style={{
+                background: 'transparent',
+                border: '1px solid oklch(100% 0 0 / 0.16)',
+                borderRadius: 'var(--radius-full)',
+                padding: 'var(--space-2) var(--space-4)',
+                color: isSaved ? 'var(--color-accent)' : 'var(--color-text-primary)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 500,
+                cursor: isSaving ? 'progress' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 'var(--space-2)',
+                opacity: isSaving ? 0.7 : 1,
+              }}
+            >
+              {isSaved ? '✓ Saved' : '+ Save to library'}
+            </button>
+          </div>
+          {saveError && (
+            <div
+              style={{
+                fontSize: 'var(--text-xs)',
+                color: '#f44',
+                marginTop: 'var(--space-1)',
+              }}
+            >
+              {saveError}
+            </div>
+          )}
         </div>
       </div>
       </div>

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -1,8 +1,13 @@
 import { type FC, useEffect, useRef, useState } from 'react';
+import { getVersion } from '@tauri-apps/api/app';
 import { cacheApi, settingsApi, ytmApi, type AppSettings, type CacheStats } from '../../lib/ipc';
 
 declare const __APP_VERSION__: string;
-const APP_VERSION = __APP_VERSION__;
+// Fallback only — the real version is fetched at runtime via Tauri's getVersion()
+// which returns the Cargo package version (what's actually bundled in the DMG).
+// Keeps Settings > About from showing a stale figure when package.json and
+// tauri.conf.json/Cargo.toml drift (issue #45).
+const FALLBACK_VERSION = __APP_VERSION__;
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -191,6 +196,7 @@ export const SettingsPage: FC = () => {
   const [settings, setSettings] = useState<AppSettings | null>(null);
   const [cacheStats, setCacheStats] = useState<CacheStats | null>(null);
   const [isClearingCache, setIsClearingCache] = useState(false);
+  const [appVersion, setAppVersion] = useState<string>(FALLBACK_VERSION);
   // Suppress the first save: we receive the persisted state from the
   // backend and would otherwise immediately round-trip it right back.
   const hydratedRef = useRef(false);
@@ -208,6 +214,12 @@ export const SettingsPage: FC = () => {
       .get()
       .then(setSettings)
       .catch((e) => console.error('settings load failed', e));
+    // Fetch the authoritative version from the Tauri runtime (Cargo/tauri.conf).
+    // This is the version actually bundled in the running app, so About can't
+    // drift from the real build (issue #45).
+    getVersion()
+      .then(setAppVersion)
+      .catch((e) => console.error('getVersion failed', e));
   }, []);
 
   useEffect(() => {
@@ -374,7 +386,7 @@ export const SettingsPage: FC = () => {
             marginBottom: 'var(--space-2)',
           }}
         >
-          VibeYTM v{APP_VERSION}
+          VibeYTM v{appVersion}
         </div>
         <div
           style={{

--- a/src/hooks/useLoginState.ts
+++ b/src/hooks/useLoginState.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { playerApi } from '../lib/ipc';
+import { useTauriEvent } from './useTauriEvent';
+
+/**
+ * Tri-state YTM sign-in status.
+ *   null  = undetermined (bridge hasn't reported yet — show a loader)
+ *   true  = signed in (skip the login gate)
+ *   false = signed out (show the LoginPage)
+ *
+ * Seeded synchronously from the Rust-side PlayerState so an already-signed-in
+ * user doesn't flash the login page on launch (issue #51).
+ */
+export function useLoginState(): boolean | null {
+  const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    playerApi
+      .getLoginState()
+      .then((state) => {
+        if (!cancelled) setLoggedIn(state);
+      })
+      .catch(() => {
+        // Backend not ready — leave as null and rely on the event stream.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useTauriEvent<boolean>('player:login-changed', (next) => {
+    setLoggedIn(next);
+  });
+
+  return loggedIn;
+}

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -86,10 +86,12 @@ export function usePlayerState(): UsePlayerState {
     // reports paused while the video element reseats the buffer, and the
     // play button would flicker to paused before the next "playing" event
     // caught up (issue #41). Drop paused events inside the echo window
-    // while we still believe we're playing.
+    // while we still believe we're playing OR buffering — the intermediate
+    // `buffering` status also arrives during a seek and would otherwise let
+    // the stale paused through.
     if (
       status === 'paused' &&
-      statusRef.current === 'playing' &&
+      (statusRef.current === 'playing' || statusRef.current === 'buffering') &&
       Date.now() - lastSeekAtRef.current < SEEK_STATUS_ECHO_WINDOW_MS
     ) {
       return;

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -28,6 +28,7 @@ export const playerApi = {
   setVolume: (level: number) => invoke('set_volume', { level }),
   getState: () => invoke<PlayerState>('get_player_state'),
   getAccountInfo: () => invoke<AccountInfo | null>('get_account_info'),
+  getLoginState: () => invoke<boolean | null>('get_login_state'),
   playTrack: (videoId: string, playlistId?: string) => invoke('play_track', { videoId, playlistId: playlistId ?? null }),
   addToQueue: (track: TrackInfo) => invoke('add_to_queue', { track }),
   removeFromQueue: (index: number) => invoke('remove_from_queue', { index }),
@@ -74,6 +75,10 @@ export const browseApi = {
   getLibrarySongs: () => invoke<TrackInfo[]>('get_library_songs'),
   getLibraryAlbums: () => invoke<AlbumSummary[]>('get_library_albums'),
   getLibraryArtists: () => invoke<ArtistSummary[]>('get_library_artists'),
+  savePlaylistToLibrary: (playlistId: string) =>
+    invoke<void>('save_playlist_to_library', { playlistId }),
+  removePlaylistFromLibrary: (playlistId: string) =>
+    invoke<void>('remove_playlist_from_library', { playlistId }),
 };
 
 export async function playFirstFromPlaylist(playlistId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Nine open issues fixed on top of 0.6.0. Full regression checklist added to `TEST_CHECKLIST.md` under "Regression Checklist for 0.7.0".

| # | Title | Fix |
|---|---|---|
| #24 | restore last played song on restart | flush session on window close so state survives <5s playback |
| #41 | play button flashes paused after seek | guard also covers `buffering→paused` transition |
| #44 | auto-retry when music fails to play | listen to YTM `onError`, retry play / seek+play / nextVideo |
| #45 | Settings › About shows wrong version | pull runtime version via Tauri `getVersion()` |
| #46 | no Save-to-library on playlist page | added "+ Save to library" toggle, new `like/like` backend |
| #47 | music keeps playing after exit when bg playback off | pause YTM before hiding main window |
| #48 | non-square covers forced into square frame | auto-detect aspect and switch to `contain` for rectangular sources |
| #50 | stale signed-in data after sign out | sidebar clears to "Not signed in"; home cache drops on sign-out event |
| #51 | login window shown when already signed in | YTM window boots hidden; LoginPage skipped when login-state = true |

## Test plan

- [x] `pnpm typecheck` — green
- [x] `cargo test` — 57 tests pass
- [x] `pnpm build` — Vite build green
- [x] `pnpm tauri build` — DMG at `src-tauri/target/release/bundle/dmg/VibeYTM_0.7.0_aarch64.dmg`
- [ ] Manual regression pass per `TEST_CHECKLIST.md` § "Regression Checklist for 0.7.0"
- [x] Manual login-flow verification (first launch signed out, relaunch signed in)
- [x] Manual background-playback OFF check (close app, audio stops)
- [x] Manual save-to-library toggle on a playlist