### PR TITLE
v0.8.0: fix 6 open issues (#54-#59) + library refresh

### DIFF
--- a/TEST_CHECKLIST.md
+++ b/TEST_CHECKLIST.md
@@ -84,6 +84,32 @@ Apply to: Home, Search (Albums/Artists tabs), Explore, Library, Playlist detail
       flashes the LoginPage or the YTM window — it boots directly into the
       main UI. The YTM window is only surfaced when sign-in is needed.
 
+## Regression Checklist for 0.8.0
+- [ ] **#54 / #55** Opening a playlist or album you have already saved
+      shows "✓ Remove from Library" on first paint. Opening one you have
+      not saved shows "+ Save to Playlists" (or "+ Save to Albums" for an
+      MPRE album). Toggling once succeeds and the next reopen reflects the
+      new state. The save call actually mutates your library on YTM.
+- [ ] After removing a saved playlist/album, clicking Back to the Library
+      page shows the item gone — no need to navigate away and return.
+- [ ] **#56** Cold launch shows a branded welcome screen (♪ logo + "VibeYTM"
+      + "Tuning in…") from the moment the window appears. It fades out
+      smoothly once Home shelves are painted. With `prefers-reduced-motion`
+      enabled, the splash hides without animation.
+- [ ] **#57** Clicking the progress bar near the very end of a short track
+      (e.g. a 1:10 song clicked at ~1:08) NEVER causes the player to stop
+      with a stale cover/title and the next song's duration. Either it
+      seeks slightly back from the end and keeps playing, or transitions
+      cleanly to the next track with all metadata in sync.
+- [ ] **#58** On the Search page, the search bar and the category filter
+      tabs stay pinned at the top while results scroll underneath, mirroring
+      the Home page's sticky greeting + mood tabs.
+- [ ] **#59** Each page's title aligns vertically with its corresponding
+      sidebar nav button — Home greeting with Home, Search bar with Search,
+      Library tab title with the Library section, Explore title with
+      Explore, Settings title with Settings, playlist Back button with the
+      sidebar nav row.
+
 ## Login Flow
 - [ ] First launch (no cached session): LoginPage appears and the YouTube
       Music window surfaces automatically so the user can sign in

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5147,7 +5147,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibeytm"
-version = "0.7.0"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibeytm"
-version = "0.7.0"
+version = "0.8.2"
 description = "An Apple Music-style YouTube Music desktop app"
 authors = ["dongli"]
 edition = "2021"

--- a/src-tauri/src/webview_bridge/poller.rs
+++ b/src-tauri/src/webview_bridge/poller.rs
@@ -341,39 +341,68 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
             } else {
                 drop(last_vid);
 
-                // Same track, but duration may have just become available
-                // (YTM occasionally reports 0 for the first few cycles while
-                // the <video> element buffers). Re-emit so the progress bar
-                // doesn't pin at the end. Also accept a *larger* duration —
-                // YTM sometimes reports a partial/buffered length first
-                // (issue #34: a 4:12 track shown as 0:29) before lengthSeconds
-                // resolves. Never shrink once we have a confirmed length.
-                if bs.duration_secs > 0.0 {
-                    let needs_update = {
-                        let ps = player_state.read().await;
-                        ps.track
-                            .as_ref()
-                            .map(|t| bs.duration_secs > t.duration_secs + 0.5)
-                            .unwrap_or(false)
-                    };
-                    if needs_update {
-                        let updated = {
-                            let mut ps = player_state.write().await;
-                            if let Some(ref mut t) = ps.track {
+                // Same videoId, but YTM's DOM can still be mid-transition.
+                // Two scenarios this branch has to repair:
+                //   * initial duration was 0 and has now filled in (issue #34)
+                //   * track auto-advanced and our previous emit captured the
+                //     new videoId alongside the OLD title/artwork, so the
+                //     frontend is stuck showing stale metadata (issue #57)
+                // Any meaningful field delta triggers a re-emit of
+                // TRACK_CHANGED with the reconciled data.
+                let needs_update = {
+                    let ps = player_state.read().await;
+                    ps.track
+                        .as_ref()
+                        .map(|t| {
+                            let duration_grew = bs.duration_secs > 0.0
+                                && bs.duration_secs > t.duration_secs + 0.5;
+                            let title_changed =
+                                !bs.title.is_empty() && bs.title != t.title;
+                            let artist_changed =
+                                !bs.artist.is_empty() && bs.artist != t.artist;
+                            let artwork_changed = !bs.artwork_url.is_empty()
+                                && t.artwork_url.as_deref() != Some(bs.artwork_url.as_str());
+                            duration_grew
+                                || title_changed
+                                || artist_changed
+                                || artwork_changed
+                        })
+                        .unwrap_or(false)
+                };
+                if needs_update {
+                    let updated = {
+                        let mut ps = player_state.write().await;
+                        if let Some(ref mut t) = ps.track {
+                            if bs.duration_secs > t.duration_secs + 0.5 {
                                 t.duration_secs = bs.duration_secs;
-                                Some(t.clone())
-                            } else {
-                                None
                             }
-                        };
-                        if let Some(track) = updated {
-                            if let Some(cache) = app.try_state::<crate::cache::Cache>() {
-                                if !track.video_id.is_empty() {
-                                    cache.put_track_duration(&track.video_id, track.duration_secs);
-                                }
+                            if !bs.title.is_empty() {
+                                t.title = bs.title.clone();
                             }
-                            let _ = app.emit("player:track-changed", &track);
+                            if !bs.artist.is_empty() {
+                                t.artist = bs.artist.clone();
+                            }
+                            if !bs.album.is_empty() {
+                                t.album = bs.album.clone();
+                            }
+                            if !bs.artwork_url.is_empty() {
+                                t.artwork_url = Some(bs.artwork_url.clone());
+                            }
+                            Some(t.clone())
+                        } else {
+                            None
                         }
+                    };
+                    if let Some(track) = updated {
+                        if let Some(cache) = app.try_state::<crate::cache::Cache>() {
+                            if track.duration_secs > 0.0 && !track.video_id.is_empty() {
+                                cache.put_track_duration(
+                                    &track.video_id,
+                                    track.duration_secs,
+                                );
+                            }
+                        }
+                        let _ = app.emit("player:track-changed", &track);
                     }
                 }
             }

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -188,7 +188,7 @@ impl YtmApi {
     /// Add a playlist to the signed-in user's library ("Saved playlists").
     /// Uses the YTM like endpoint with the playlist as the target — the same
     /// call the YTM web UI's save button makes, which adds the playlist to
-    /// FEmusic_liked_playlists (issue #46).
+    /// FEmusic_liked_playlists (issues #46, #54).
     pub async fn save_playlist_to_library(
         &self,
         app: &AppHandle,
@@ -198,10 +198,10 @@ impl YtmApi {
             "target": { "playlistId": playlist_id }
         })
         .to_string();
-        ytm_api_call(app, "like/like", &body)
+        let raw = ytm_api_call(app, "like/like", &body)
             .await
             .map_err(anyhow::Error::msg)?;
-        Ok(())
+        check_like_response(&raw, "like")
     }
 
     /// Remove a playlist from the signed-in user's library. Mirror of
@@ -215,11 +215,31 @@ impl YtmApi {
             "target": { "playlistId": playlist_id }
         })
         .to_string();
-        ytm_api_call(app, "like/removelike", &body)
+        let raw = ytm_api_call(app, "like/removelike", &body)
             .await
             .map_err(anyhow::Error::msg)?;
-        Ok(())
+        check_like_response(&raw, "removelike")
     }
+}
+
+/// YTM returns a minimal JSON body on success (responseContext + actions).
+/// A failure surfaces as `{ "error": { "code": N, "message": "..." } }`.
+/// Propagate that as an Err so the UI can roll back the optimistic toggle.
+fn check_like_response(raw: &str, action: &str) -> anyhow::Result<()> {
+    let parsed: Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(action, error = %e, "could not parse like response; treating as success");
+            return Ok(());
+        }
+    };
+    if let Some(err) = parsed.get("error") {
+        let code = err["code"].as_i64().unwrap_or(-1);
+        let message = err["message"].as_str().unwrap_or("");
+        tracing::error!(action, code, message, "YTM rejected like call");
+        anyhow::bail!("YTM error {code}: {message}");
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -852,6 +872,17 @@ fn parse_playlist_detail(data: &Value, playlist_id: &str) -> PlaylistDetail {
         Some(tracks.len() as u32)
     };
 
+    // --- Library toggle state + audio playlist ID (issues #54, #55) ---
+    let library_toggle = extract_library_save_toggle(data);
+    let is_in_library = library_toggle.as_ref().map(|t| t.is_toggled).unwrap_or(false);
+    // Prefer the toggle's own target — it's the canonical ID YTM's own save
+    // button posts to /like/like with. Fall back to a watch-endpoint scan
+    // for any older response shapes.
+    let audio_playlist_id = library_toggle
+        .and_then(|t| t.target_playlist_id)
+        .or_else(|| extract_audio_playlist_id(data));
+    let is_album = playlist_id.starts_with("MPRE");
+
     PlaylistDetail {
         playlist_id: playlist_id.to_string(),
         title,
@@ -859,7 +890,121 @@ fn parse_playlist_detail(data: &Value, playlist_id: &str) -> PlaylistDetail {
         artwork_url,
         track_count,
         tracks,
+        is_in_library,
+        audio_playlist_id,
+        is_album,
     }
+}
+
+struct LibrarySaveToggle {
+    is_toggled: bool,
+    target_playlist_id: Option<String>,
+}
+
+/// Find the header's "Save to library" toggle button and read both its
+/// `isToggled` flag and the playlistId it posts to (issues #54, #55).
+///
+/// In current YTM responses this is a `toggleButtonRenderer` whose
+/// `defaultServiceEndpoint.likeEndpoint` carries `target.playlistId`. The
+/// icon pair is `BOOKMARK_BORDER` ↔ `BOOKMARK`. Older responses sometimes
+/// used `LIBRARY_ADD` ↔ `LIBRARY_SAVED`, so we accept either signal.
+fn extract_library_save_toggle(data: &Value) -> Option<LibrarySaveToggle> {
+    fn walk(val: &Value, depth: u8) -> Option<LibrarySaveToggle> {
+        if depth > 14 {
+            return None;
+        }
+        if let Some(toggle) = val.get("toggleButtonRenderer") {
+            let default_icon =
+                toggle["defaultIcon"]["iconType"].as_str().unwrap_or("");
+            let toggled_icon =
+                toggle["toggledIcon"]["iconType"].as_str().unwrap_or("");
+            let has_like_endpoint =
+                toggle["defaultServiceEndpoint"].get("likeEndpoint").is_some()
+                    || toggle["toggledServiceEndpoint"]
+                        .get("likeEndpoint")
+                        .is_some();
+            let icon_matches = default_icon == "BOOKMARK_BORDER"
+                || default_icon == "BOOKMARK"
+                || toggled_icon == "BOOKMARK"
+                || default_icon.contains("LIBRARY")
+                || toggled_icon.contains("LIBRARY");
+            if has_like_endpoint || icon_matches {
+                if let Some(is_toggled) = toggle["isToggled"].as_bool() {
+                    let target_playlist_id = toggle["defaultServiceEndpoint"]
+                        ["likeEndpoint"]["target"]["playlistId"]
+                        .as_str()
+                        .or_else(|| {
+                            toggle["toggledServiceEndpoint"]["likeEndpoint"]
+                                ["target"]["playlistId"]
+                                .as_str()
+                        })
+                        .map(|s| s.to_string());
+                    return Some(LibrarySaveToggle {
+                        is_toggled,
+                        target_playlist_id,
+                    });
+                }
+            }
+        }
+        match val {
+            Value::Object(map) => {
+                for v in map.values() {
+                    if let Some(found) = walk(v, depth + 1) {
+                        return Some(found);
+                    }
+                }
+            }
+            Value::Array(arr) => {
+                for v in arr {
+                    if let Some(found) = walk(v, depth + 1) {
+                        return Some(found);
+                    }
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+    walk(data, 0)
+}
+
+/// Fallback: pull a playable playlist ID (OLAK*, RDCLAK*, PL*) from any
+/// watch endpoint in the response, used only when no toggle button surfaces
+/// one (issue #54).
+fn extract_audio_playlist_id(data: &Value) -> Option<String> {
+    fn walk(val: &Value, depth: u8) -> Option<String> {
+        if depth > 12 {
+            return None;
+        }
+        for key in ["watchEndpoint", "watchPlaylistEndpoint"] {
+            if let Some(ep) = val.get(key) {
+                if let Some(id) = ep["playlistId"].as_str() {
+                    if id.starts_with("OLAK") || id.starts_with("RDCLAK") || id.starts_with("PL") {
+                        return Some(id.to_string());
+                    }
+                }
+            }
+        }
+        match val {
+            Value::Object(map) => {
+                for v in map.values() {
+                    if let Some(found) = walk(v, depth + 1) {
+                        return Some(found);
+                    }
+                }
+            }
+            Value::Array(arr) => {
+                for v in arr {
+                    if let Some(found) = walk(v, depth + 1) {
+                        return Some(found);
+                    }
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+    walk(data, 0)
 }
 
 fn parse_explore_shelves(data: &Value) -> Vec<Shelf> {
@@ -1711,5 +1856,83 @@ mod tests {
     fn parse_search_suggestions_empty_for_bad_shape() {
         assert!(parse_search_suggestions(&json!({})).is_empty());
         assert!(parse_search_suggestions(&json!(null)).is_empty());
+    }
+
+    // ---- extract_library_save_toggle -------------------------------------
+
+    /// YTM's playlist/album header save toggle uses BOOKMARK_BORDER (default,
+    /// not saved) ↔ BOOKMARK (toggled, saved) and a `likeEndpoint` carrying
+    /// the canonical save target (issues #54, #55).
+    #[test]
+    fn extract_library_save_toggle_reads_bookmark_button() {
+        let data = json!({
+            "wrapper": {
+                "musicResponsiveHeaderRenderer": {
+                    "buttons": [
+                        { "downloadButtonRenderer": {} },
+                        {
+                            "toggleButtonRenderer": {
+                                "isToggled": true,
+                                "defaultIcon": { "iconType": "BOOKMARK_BORDER" },
+                                "toggledIcon": { "iconType": "BOOKMARK" },
+                                "defaultServiceEndpoint": {
+                                    "likeEndpoint": {
+                                        "status": "LIKE",
+                                        "target": { "playlistId": "OLAK5uy_test" }
+                                    }
+                                },
+                                "toggledServiceEndpoint": {
+                                    "likeEndpoint": {
+                                        "status": "INDIFFERENT",
+                                        "target": { "playlistId": "OLAK5uy_test" }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+        let toggle = extract_library_save_toggle(&data).expect("expected toggle");
+        assert!(toggle.is_toggled);
+        assert_eq!(toggle.target_playlist_id.as_deref(), Some("OLAK5uy_test"));
+    }
+
+    #[test]
+    fn extract_library_save_toggle_returns_false_when_not_saved() {
+        let data = json!({
+            "x": {
+                "toggleButtonRenderer": {
+                    "isToggled": false,
+                    "defaultIcon": { "iconType": "BOOKMARK_BORDER" },
+                    "toggledIcon": { "iconType": "BOOKMARK" },
+                    "defaultServiceEndpoint": {
+                        "likeEndpoint": {
+                            "status": "LIKE",
+                            "target": { "playlistId": "RDCLAK5uy" }
+                        }
+                    }
+                }
+            }
+        });
+        let toggle = extract_library_save_toggle(&data).unwrap();
+        assert!(!toggle.is_toggled);
+        assert_eq!(toggle.target_playlist_id.as_deref(), Some("RDCLAK5uy"));
+    }
+
+    #[test]
+    fn extract_library_save_toggle_none_for_unrelated_toggle() {
+        // A toggle with no like endpoint and no bookmark/library icons should
+        // not be mistaken for the save button (e.g. shuffle, autoplay).
+        let data = json!({
+            "x": {
+                "toggleButtonRenderer": {
+                    "isToggled": true,
+                    "defaultIcon": { "iconType": "SHUFFLE" },
+                    "toggledIcon": { "iconType": "SHUFFLE" }
+                }
+            }
+        });
+        assert!(extract_library_save_toggle(&data).is_none());
     }
 }

--- a/src-tauri/src/ytm_api/types.rs
+++ b/src-tauri/src/ytm_api/types.rs
@@ -60,6 +60,21 @@ pub struct PlaylistDetail {
     pub artwork_url: String,
     pub track_count: Option<u32>,
     pub tracks: Vec<TrackInfo>,
+    /// Whether this playlist/album is already saved in the user's library.
+    /// Extracted from the header's toggle-button state when available so the
+    /// Save/Remove label can render correctly on first paint (issue #55).
+    #[serde(default)]
+    pub is_in_library: bool,
+    /// The `audioPlaylistId` (typically an OLAK* ID) that library operations
+    /// should target. For user playlists this matches `playlist_id`; for
+    /// albums (MPRE browseId) this is the underlying playable playlist used
+    /// by YTM's save endpoint (issue #54).
+    #[serde(default)]
+    pub audio_playlist_id: Option<String>,
+    /// Whether this detail represents an album (MPRE browseId), so the UI
+    /// can pick the correct "saved to Albums / Playlists" label (issue #55).
+    #[serde(default)]
+    pub is_album: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "0.7.0",
+  "version": "0.8.2",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ExplorePage } from './components/pages/ExplorePage';
 import { SettingsPage } from './components/pages/SettingsPage';
 import { LoginPage } from './components/pages/LoginPage';
 import { PlaylistDetailPage } from './components/pages/PlaylistDetailPage';
+import { WelcomeScreen } from './components/WelcomeScreen';
 import { useLoginState } from './hooks/useLoginState';
 import { ytmApi } from './lib/ipc';
 
@@ -26,6 +27,20 @@ const App: FC = () => {
   const [isNowPlayingOpen, setIsNowPlayingOpen] = useState(false);
   const [viewingPlaylist, setViewingPlaylist] = useState<ViewingPlaylist | null>(null);
   const [pendingSearchQuery, setPendingSearchQuery] = useState<string | null>(null);
+  // Flips true once the Home page has finished its first real render (or we
+  // settle into the LoginPage for signed-out users). While false, the
+  // WelcomeScreen stays overlaid so cold launch never shows the "Loading…"
+  // placeholder or a half-painted Home (issue #56).
+  const [isHomeReady, setIsHomeReady] = useState(false);
+  const handleHomeReady = useCallback(() => setIsHomeReady(true), []);
+  // Bumped whenever the user saves or removes a playlist/album so the
+  // LibraryPage knows to refetch even when it stays mounted under the
+  // playlist-detail overlay.
+  const [libraryVersion, setLibraryVersion] = useState(0);
+  const handleLibraryChanged = useCallback(
+    () => setLibraryVersion((v) => v + 1),
+    [],
+  );
   // Remembered so "Settings → Settings" toggles back to where the user was.
   const previousPathRef = useRef<string>('home');
 
@@ -64,27 +79,21 @@ const App: FC = () => {
     }
   }, [loginState]);
 
-  // While we don't know the login state, show a neutral placeholder instead
-  // of flashing the login page first.
+  // While we don't know the login state, the WelcomeScreen is the only thing
+  // on screen — no neutral "Loading…" flash.
   if (loginState === null && !loginOverride) {
-    return (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100vh',
-          color: 'var(--color-text-tertiary)',
-          fontSize: 'var(--text-base)',
-        }}
-      >
-        Loading…
-      </div>
-    );
+    return <WelcomeScreen isDone={false} />;
   }
 
   if (!isLoggedIn) {
-    return <LoginPage onLoggedIn={() => setLoginOverride(true)} />;
+    // Once we know the user is signed out, the LoginPage is ready to render
+    // behind the fading WelcomeScreen.
+    return (
+      <>
+        <LoginPage onLoggedIn={() => setLoginOverride(true)} />
+        <WelcomeScreen isDone />
+      </>
+    );
   }
 
   const renderPage = () => {
@@ -121,6 +130,7 @@ const App: FC = () => {
           onOpenPlaylist={openPlaylistDetail}
           onAutoPlayPlaylist={openPlaylistAutoPlay}
           onSearchArtist={searchForArtist}
+          refreshKey={libraryVersion}
         />
       );
     }
@@ -128,11 +138,13 @@ const App: FC = () => {
       <HomePage
         onOpenPlaylist={openPlaylistDetail}
         onAutoPlayPlaylist={openPlaylistAutoPlay}
+        onReady={handleHomeReady}
       />
     );
   };
 
   return (
+    <>
     <AppShell
       currentPath={currentPath}
       onNavigate={(path) => {
@@ -175,11 +187,14 @@ const App: FC = () => {
               playlistId={viewingPlaylist.id}
               autoPlay={viewingPlaylist.autoPlay}
               onBack={() => setViewingPlaylist(null)}
+              onLibraryChanged={handleLibraryChanged}
             />
           </div>
         )}
       </div>
     </AppShell>
+    <WelcomeScreen isDone={isHomeReady} />
+    </>
   );
 };
 

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,0 +1,125 @@
+import { type FC, useEffect, useState } from 'react';
+
+interface WelcomeScreenProps {
+  /** When true, start fading out; unmounts once the transition finishes. */
+  isDone: boolean;
+}
+
+const FADE_MS = 450;
+
+/**
+ * Branded splash shown from the first paint of the window until the Home
+ * page (or LoginPage) is fully rendered (issue #56). Respects
+ * `prefers-reduced-motion` by skipping the fade transition.
+ */
+export const WelcomeScreen: FC<WelcomeScreenProps> = ({ isDone }) => {
+  const [isMounted, setIsMounted] = useState(true);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduceMotion(mq.matches);
+    const listener = (e: MediaQueryListEvent) => setReduceMotion(e.matches);
+    mq.addEventListener('change', listener);
+    return () => mq.removeEventListener('change', listener);
+  }, []);
+
+  useEffect(() => {
+    if (!isDone) return;
+    if (reduceMotion) {
+      setIsMounted(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setIsMounted(false), FADE_MS);
+    return () => window.clearTimeout(timer);
+  }, [isDone, reduceMotion]);
+
+  if (!isMounted) return null;
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 500,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background:
+          'radial-gradient(circle at 50% 35%, oklch(22% 0.02 25 / 1) 0%, var(--color-bg) 75%)',
+        opacity: isDone && !reduceMotion ? 0 : 1,
+        transition: reduceMotion
+          ? 'none'
+          : `opacity ${FADE_MS}ms var(--ease-out)`,
+        pointerEvents: isDone ? 'none' : 'auto',
+        userSelect: 'none',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 'var(--space-5)',
+        }}
+      >
+        {/* Logo mark — a glowing musical note in the app's accent color */}
+        <div
+          style={{
+            width: 96,
+            height: 96,
+            borderRadius: 'var(--radius-xl)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background:
+              'linear-gradient(140deg, var(--color-accent-hover) 0%, var(--color-accent) 100%)',
+            boxShadow:
+              '0 20px 48px oklch(62% 0.24 25 / 0.35), 0 2px 12px oklch(0% 0 0 / 0.4)',
+            fontSize: 56,
+            lineHeight: 1,
+            color: 'oklch(100% 0 0)',
+            animation: reduceMotion
+              ? undefined
+              : 'vibeytm-welcome-pulse 1800ms var(--ease-out) infinite',
+          }}
+        >
+          {'♪'}
+        </div>
+
+        <div style={{ textAlign: 'center' }}>
+          <div
+            style={{
+              fontSize: 'var(--text-2xl)',
+              fontWeight: 700,
+              color: 'var(--color-text-primary)',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            VibeYTM
+          </div>
+          <div
+            style={{
+              marginTop: 'var(--space-2)',
+              fontSize: 'var(--text-sm)',
+              color: 'var(--color-text-tertiary)',
+              letterSpacing: '0.02em',
+            }}
+          >
+            Tuning in…
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes vibeytm-welcome-pulse {
+          0%, 100% { transform: scale(1); filter: brightness(1); }
+          50% { transform: scale(1.06); filter: brightness(1.1); }
+        }
+      `}</style>
+    </div>
+  );
+};

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -330,7 +330,14 @@ export const PlayerBar: FC<PlayerBarProps> = ({
               // waiting for the backend round-trip. markSeek lets the hook
               // discard stale pre-seek position echoes from the bridge poller
               // that would otherwise bounce the thumb back to the old spot.
-              const next = Number(e.target.value);
+              const raw = Number(e.target.value);
+              // Clamp to `duration - 1.25s` so a click at the very end of a
+              // short track can't trigger YTM's end-of-video auto-advance.
+              // That race causes the <video> element to swap mid-poll, and
+              // we briefly emit new duration + old cover/title (issue #57).
+              const next = duration > 0
+                ? Math.min(raw, Math.max(0, duration - 1.25))
+                : raw;
               markSeek(next);
               // If we're currently playing, force the optimistic status
               // back to 'playing' too. During a seek YTM briefly reports

--- a/src/components/pages/ExplorePage.tsx
+++ b/src/components/pages/ExplorePage.tsx
@@ -124,7 +124,9 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          paddingTop: 'var(--space-8)',
+          // Align the Explore title with the sidebar's Explore button
+          // (issue #59).
+          paddingTop: 'var(--space-3)',
           paddingBottom: 'var(--space-4)',
           marginBottom: 'var(--space-4)',
         }}

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -9,6 +9,12 @@ import { SongRow } from '../browse/SongRow';
 interface HomePageProps {
   onOpenPlaylist?: (playlistId: string) => void;
   onAutoPlayPlaylist?: (playlistId: string) => void;
+  /**
+   * Fires once the home page has finished loading shelves (or surfaced an
+   * empty state). Used by App.tsx to dismiss the welcome splash at the
+   * earliest moment there's something real to look at (issue #56).
+   */
+  onReady?: () => void;
 }
 
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
@@ -48,7 +54,7 @@ const getGreeting = (): string => {
   return 'Good evening';
 };
 
-export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
+export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist, onReady }) => {
   const [shelves, setShelves] = useState<Shelf[]>(cachedShelves ?? []);
   const [isLoading, setIsLoading] = useState(!cachedShelves);
   const [activeMood, setActiveMood] = useState<MoodTab>(lastActiveMood);
@@ -70,6 +76,8 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
     if (!shouldForce && cachedShelves && Date.now() - cachedAt < CACHE_TTL_MS) {
       setShelves(cachedShelves);
       setIsLoading(false);
+      // Warm cache path still needs to dismiss the splash (issue #56).
+      onReady?.();
       return;
     }
     setIsLoading(true);
@@ -81,11 +89,18 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
         firstLoadDone = true;
         setShelves(data);
         setIsLoading(false);
+        onReady?.();
       })
       .catch((e) => {
         console.error('[HomePage] getHome failed:', e);
         setIsLoading(false);
+        // Still dismiss the welcome splash — users shouldn't get stuck on
+        // it if the first fetch fails.
+        onReady?.();
       });
+    // onReady intentionally omitted — we only want to refetch on explicit
+    // triggers, not when the parent remounts the callback identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -179,7 +194,9 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist }) => {
           background: 'var(--color-surface-1)',
           backdropFilter: 'blur(12px)',
           WebkitBackdropFilter: 'blur(12px)',
-          paddingTop: 'var(--space-8)',
+          // Match the sidebar nav's top padding so the greeting vertically
+          // aligns with the Home button (issue #59).
+          paddingTop: 'var(--space-3)',
           paddingBottom: 'var(--space-3)',
           marginBottom: 'var(--space-3)',
         }}

--- a/src/components/pages/LibraryPage.tsx
+++ b/src/components/pages/LibraryPage.tsx
@@ -16,6 +16,13 @@ interface LibraryPageProps {
   onOpenPlaylist?: (playlistId: string) => void;
   onAutoPlayPlaylist?: (playlistId: string) => void;
   onSearchArtist?: (name: string) => void;
+  /**
+   * Bumped by the parent whenever a save/remove succeeds elsewhere in the
+   * app. Including it in the fetch effect's deps forces a refetch so the
+   * underlying mounted LibraryPage doesn't show a removed playlist when
+   * the user closes the playlist-detail overlay.
+   */
+  refreshKey?: number;
 }
 
 const TAB_TITLES: Record<LibraryTab, string> = {
@@ -29,6 +36,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({
   activeTab,
   onOpenPlaylist,
   onSearchArtist,
+  refreshKey = 0,
 }) => {
   const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
   const [songs, setSongs] = useState<TrackInfo[]>([]);
@@ -76,27 +84,43 @@ export const LibraryPage: FC<LibraryPageProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [activeTab]);
+  }, [activeTab, refreshKey]);
 
   return (
     <section
       style={{
-        padding: 'var(--space-8) var(--space-6)',
+        padding: '0 var(--space-6) var(--space-8)',
         overflowY: 'auto',
         height: '100%',
       }}
     >
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 10,
+          background: 'var(--color-surface-1)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          // Line the library title up with the sidebar's Library group
+          // headings (issue #59).
+          paddingTop: 'var(--space-3)',
+          paddingBottom: 'var(--space-4)',
+          marginBottom: 'var(--space-4)',
+        }}
+      >
       <h1
         style={{
           fontSize: 'var(--text-2xl)',
           fontWeight: 700,
-          marginBottom: 'var(--space-6)',
           letterSpacing: '-0.02em',
           color: 'var(--color-text-primary)',
+          margin: 0,
         }}
       >
         {TAB_TITLES[activeTab]}
       </h1>
+      </div>
 
       {isLoading && (
         <p style={{ fontSize: 'var(--text-base)', color: 'var(--color-text-tertiary)' }}>

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -8,21 +8,34 @@ interface PlaylistDetailPageProps {
   playlistId: string;
   autoPlay?: boolean;
   onBack: () => void;
+  /**
+   * Fired after a successful save or remove so the parent can invalidate
+   * any cached library data — otherwise a removed playlist still appears
+   * in LibraryPage when the user clicks Back.
+   */
+  onLibraryChanged?: () => void;
 }
 
 export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
   playlistId,
   autoPlay = false,
   onBack,
+  onLibraryChanged,
 }) => {
   const [playlist, setPlaylist] = useState<PlaylistDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // Tri-state local view of whether the playlist is saved. Optimistic — the
-  // backend call confirms after the click, and we roll back on failure.
+  // Tri-state local view of whether the playlist is saved. Seeded from the
+  // YTM response's header toggle-button state (issue #55), then kept
+  // optimistic across user clicks.
   const [isSaved, setIsSaved] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  const isAlbum = playlist?.isAlbum ?? playlistId.startsWith('MPRE');
+  // Albums save via their underlying audioPlaylistId (OLAK*), not the MPRE
+  // browseId. Fall back to playlistId when the backend didn't surface one.
+  const saveTargetId = playlist?.audioPlaylistId || playlistId;
 
   const toggleSaved = async () => {
     if (isSaving) return;
@@ -32,15 +45,20 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
     setIsSaved(next); // optimistic
     try {
       if (next) {
-        await browseApi.savePlaylistToLibrary(playlistId);
+        await browseApi.savePlaylistToLibrary(saveTargetId);
       } else {
-        await browseApi.removePlaylistFromLibrary(playlistId);
+        await browseApi.removePlaylistFromLibrary(saveTargetId);
       }
+      // Tell the parent so cached library/album lists rebuild before the
+      // user clicks Back into them.
+      onLibraryChanged?.();
     } catch (e: unknown) {
       // Roll back and surface the error so the user knows it didn't stick.
       setIsSaved(!next);
       setSaveError(
-        next ? 'Could not save to library' : 'Could not remove from library',
+        next
+          ? `Could not save to ${isAlbum ? 'Albums' : 'Playlists'}`
+          : `Could not remove from ${isAlbum ? 'Albums' : 'Playlists'}`,
       );
       console.error('[PlaylistDetailPage] save toggle failed:', e);
     } finally {
@@ -62,6 +80,10 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
       .then(([data, currentState]) => {
         if (cancelled) return;
         setPlaylist(data);
+        // Seed the saved-state from the server so the button renders the
+        // correct label on first paint (issue #55). Without this the button
+        // always starts as "Save to library" even for already-saved content.
+        setIsSaved(data.isInLibrary ?? false);
         setIsLoading(false);
 
         if (autoPlay && data.tracks.length > 0 && data.tracks[0].videoId) {
@@ -228,7 +250,9 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
           background: 'var(--color-surface-1)',
           backdropFilter: 'blur(12px)',
           WebkitBackdropFilter: 'blur(12px)',
-          paddingTop: 'var(--space-6)',
+          // Match the sidebar nav's top padding so the back button lines
+          // up with the sidebar navigation (issue #59).
+          paddingTop: 'var(--space-3)',
           paddingBottom: 'var(--space-4)',
           marginBottom: 'var(--space-4)',
         }}
@@ -403,7 +427,9 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
                 opacity: isSaving ? 0.7 : 1,
               }}
             >
-              {isSaved ? '✓ Saved' : '+ Save to library'}
+              {isSaved
+                ? '✓ Remove from Library'
+                : `+ Save to ${isAlbum ? 'Albums' : 'Playlists'}`}
             </button>
           </div>
           {saveError && (

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -210,11 +210,30 @@ export const SearchPage: FC<SearchPageProps> = ({
   return (
     <section
       style={{
-        padding: 'var(--space-8) var(--space-6)',
+        padding: '0 var(--space-6) var(--space-8)',
         overflowY: 'auto',
         height: '100%',
       }}
     >
+      {/*
+        Sticky wrapper keeps the search bar + category tabs pinned while the
+        results scroll underneath (issue #58). Top padding matches the
+        sidebar nav so the search bar lines up with the Search button
+        (issue #59).
+      */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 20,
+          background: 'var(--color-surface-1)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          paddingTop: 'var(--space-3)',
+          paddingBottom: 'var(--space-3)',
+          marginBottom: 'var(--space-3)',
+        }}
+      >
       <div
         style={{
           position: 'relative',
@@ -355,7 +374,6 @@ export const SearchPage: FC<SearchPageProps> = ({
         style={{
           display: 'flex',
           gap: 'var(--space-2)',
-          marginBottom: 'var(--space-6)',
           overflowX: 'auto',
           scrollbarWidth: 'none',
         }}
@@ -387,6 +405,7 @@ export const SearchPage: FC<SearchPageProps> = ({
             </button>
           );
         })}
+      </div>
       </div>
 
       {isLoading && (

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -261,7 +261,7 @@ export const SettingsPage: FC = () => {
   return (
     <section
       style={{
-        padding: 'var(--space-8) var(--space-6)',
+        padding: '0 var(--space-6) var(--space-8)',
         overflowY: 'auto',
         height: '100%',
         maxWidth: '640px',
@@ -273,6 +273,9 @@ export const SettingsPage: FC = () => {
           fontWeight: 700,
           letterSpacing: '-0.02em',
           color: 'var(--color-text-primary)',
+          // Match the sidebar Settings button's vertical position
+          // (issue #59).
+          paddingTop: 'var(--space-3)',
           marginBottom: 'var(--space-2)',
         }}
       >

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,6 +59,12 @@ export interface PlaylistDetail {
   artworkUrl: string;
   trackCount?: number;
   tracks: TrackInfo[];
+  /** Whether the current user already has this in their library. */
+  isInLibrary?: boolean;
+  /** Playable playlist ID for library operations (OLAK* for albums). */
+  audioPlaylistId?: string | null;
+  /** True when this detail represents an album (MPRE browseId). */
+  isAlbum?: boolean;
 }
 
 export interface SearchResults {


### PR DESCRIPTION
## Summary
Fixes 6 open issues filed against v0.7.0 plus a follow-up library-refresh bug discovered during manual testing.

| # | Fix |
|---|-----|
| 54 | Save-to-library actually mutates the user's library — backend now reads the canonical `likeEndpoint.target.playlistId` from the YTM header toggle and validates the response. |
| 55 | Saved state is correct on first paint via `isInLibrary` extracted from the BOOKMARK toggle. Button labels split "Save to Albums" / "Save to Playlists" / "Remove from Library". |
| 56 | New `WelcomeScreen` splash overlays from window-open until Home is ready; fades out and respects `prefers-reduced-motion`. |
| 57 | Seek slider clamps to `duration - 1.25s` so near-end clicks don't trigger YTM auto-advance; poller re-emits `TRACK_CHANGED` when title/artist/artwork drift for the same videoId so a half-transitioned DOM snapshot self-heals. |
| 58 | Search bar + category tabs are sticky like the Home greeting + mood tabs. |
| 59 | Reduced top padding on Home, Search, Library, Explore, Settings, PlaylistDetail so titles line up with the sidebar nav buttons. |

Plus: an `App.libraryVersion` counter bumped on save/remove so `LibraryPage` refetches when the user clicks Back into it (otherwise the underlying mounted page kept showing the removed playlist until they navigated away and returned).

## Test plan
- [ ] Open a playlist you have saved → button reads "✓ Remove from Library" on first paint
- [ ] Open one you haven't saved → "+ Save to Playlists" (or "+ Save to Albums" for an MPRE album)
- [ ] Toggle, close detail, reopen — label persists
- [ ] Remove a saved playlist → click Back → it's gone from the Library page (no manual refresh needed)
- [ ] Cold launch shows branded splash, fades to Home
- [ ] Click progress bar at the very end of a 1:10 song — playback continues; cover/title/duration stay in sync
- [ ] Search page: scroll results — search bar + tabs stay pinned at top
- [ ] Each page title vertically aligns with its sidebar nav button

🤖 Generated with [Claude Code](https://claude.com/claude-code)