### PR TITLE
v0.9.0: timed lyrics pipeline + blur-reload UX

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1277,3 +1277,86 @@ see `git log` for the exhaustive list.
   - Integration: `src-tauri/tests/account_info_integration.rs` (3 tests) —
     locks the wire contract between the bridge JS, Rust poller, and
     frontend `AccountInfo` type.
+
+### v0.9.0 — Lyrics pipeline, karaoke UI, reload polish
+
+- **Three-tier timed lyrics fallback**:
+  1. YTM's own timed lyrics from
+     `contents.elementRenderer.newElement.type.componentType.model.timedLyricsModel.lyricsData.timedLyricsData`
+     when available.
+  2. Parallel race of LRCLIB and NetEase via `tokio::select!` —
+     `fetch_lrclib_synced` against `https://lrclib.net/api/get` and
+     `fetch_netease_synced` against `music.163.com` (search → `song/lyric`).
+     First `Some(data)` wins; `None` results wait for the other. LRCLIB
+     covers Western catalog, NetEase covers Mandopop/CJK.
+  3. Plain text with evenly-distributed synthetic timings so the panel
+     still scrolls when neither source has synced lines.
+  The external fallbacks run only when YTM confirmed lyrics exist; a
+  `messageRenderer: "Lyrics not available"` short-circuits so
+  instrumentals don't get the vocal original's lyrics pasted onto them.
+
+- **YTM request context upgrade**: `webview_bridge::api::ytm_api_call`
+  now reads `window.ytcfg.get('INNERTUBE_CONTEXT')` and
+  `INNERTUBE_API_KEY` from inside the YTM webview, replacing the
+  hand-crafted 4-field context. Adds `X-YouTube-Client-Name: 67` and
+  `X-YouTube-Client-Version` headers, plus `&key=<api_key>` on the URL —
+  matching what YTM web sends and unlocking Elements-rendered responses
+  the minimal context missed.
+
+- **Persistent lyrics cache** at `{app_data}/cache/lyrics/{videoId}.json`
+  alongside `tracks/` and `images/`. `Cache::get_lyrics` / `put_lyrics`
+  methods, 7-day + jitter TTL, included in `Cache::clear`. Only content-
+  bearing results are persisted; empty stubs and transient errors stay
+  un-cached so a future probe can still populate them.
+
+- **In-memory cache + de-dupe** (`src/hooks/useLyrics.ts`): shared
+  `lyricsCache` and `lyricsMisses` maps keyed by videoId, plus an
+  `inFlight` promise map so `PlayerBar` (pre-probe) and `NowPlaying`
+  (on-demand) share the same fetch. Single-retry after 1.5 s on
+  transient error handles webview-navigation races.
+
+- **Pre-fetch + upcoming-queue preload**: `PlayerBar` calls
+  `useLyrics(track, true, true)` so the fetch starts the instant a track
+  loads. Separately, new `get_upcoming_tracks(video_id, limit)` command
+  parses YTM's upcoming queue from `playlistPanelRenderer.contents`
+  (handles both the direct `playlistPanelVideoRenderer` form and the
+  newer `playlistPanelVideoWrapperRenderer.primaryRenderer` wrap), then
+  fires `preloadLyrics` on the first two results so skipping forward
+  usually hits cache.
+
+- **Karaoke UI** (`NowPlaying` + `LyricLineView`): each line renders as
+  two stacked copies — a base at the title color and an absolute overlay
+  in the same color with `clip-path: inset(0 (1-progress)*100% 0 0)`
+  revealing left-to-right as the vocal advances. Container auto-scrolls
+  to keep the active line centered; first scroll per visibility session
+  is instant (`behavior: 'auto'`), subsequent advances are smooth. First
+  scroll waits 450 ms after the panel opens so the column's width
+  transition has settled before measuring.
+
+- **Split playing-page layout**: single row used in both cover-only and
+  lyrics-open modes. Lyrics column width animates `0` →
+  `calc(coverSide / 2)` over 420 ms with `marginLeft` and `opacity` in
+  sync, so toggling LRC is a smooth transition rather than a tree
+  remount. Cover takes 2/3 of the 1200 px-capped row, lyrics 1/3; cover
+  side length computed once and used identically in both modes so
+  toggling never resizes it. Panel top-aligns with the sidebar's Home
+  button via `paddingTop: var(--space-3)`.
+
+- **LRC button**: always clickable. Pre-probe runs on every
+  `track.videoId` change so state is ready before the user clicks. Dim
+  opacity communicates "no lyrics" without disabling — the user can open
+  the panel to see the "No lyrics for this track" message.
+
+- **Blur-and-spinner reload pattern** (`src/components/LoadingOverlay.tsx`):
+  new `<LoadingSpinner>` and `<ReloadOverlay>` primitives. Home, Explore,
+  Library, PlaylistDetail, and Search now keep previously-rendered
+  content visible with a 10 px blur + centered spinner while refetching,
+  instead of wiping to a "Loading…" placeholder. First-load on each page
+  still shows a bare spinner since there's nothing to blur.
+
+- **Data-model additions**:
+  - `Lyrics { text, source?, lines? }` and
+    `LyricLine { startMs, endMs?, text }`, serialized camelCase; mirrored
+    in TS `src/lib/types.ts`.
+  - New commands: `get_lyrics(video_id, artist?, title?, duration_secs?)`,
+    `get_upcoming_tracks(video_id, limit?)`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ An Apple Music-style YouTube Music desktop app built with Tauri, React, and Rust
 - Desktop notifications on track change
 - Global keyboard shortcuts (configurable)
 - Queue management with drag-to-reorder
-- Synced lyrics display
+- Synced lyrics display with karaoke-style per-line highlighting (YTM timed lyrics → LRCLIB → NetEase fallback, persisted per-track on disk)
+- Lyrics pre-fetch for the current track and the next two in YTM's upcoming queue
+- Blur-and-spinner on reload — refreshing a page keeps previous content visible while fresh data arrives
 - Custom CSS themes (coming soon)
 
 ## Screenshots

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5147,7 +5147,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibeytm"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibeytm"
-version = "0.8.2"
+version = "0.9.0"
 description = "An Apple Music-style YouTube Music desktop app"
 authors = ["dongli"]
 edition = "2021"

--- a/src-tauri/src/cache/mod.rs
+++ b/src-tauri/src/cache/mod.rs
@@ -1,13 +1,14 @@
-//! Disk cache for images and track metadata.
+//! Disk cache for images, track metadata, and lyrics.
 //!
 //! Layout:
 //!   {app_data}/cache/
 //!     images/{sha256(url)}.bin
 //!     tracks/{videoId}.json
+//!     lyrics/{videoId}.json
 //!
 //! Images are capped at `MAX_IMAGE_CACHE_BYTES` with LRU eviction (based on
-//! file mtime). Track metadata is a small JSON side-cache and is included in
-//! cache stats but not heavily constrained.
+//! file mtime). Track + lyrics metadata are small JSON side-caches and are
+//! included in cache stats but not heavily constrained.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -54,10 +55,49 @@ impl Cache {
             .with_context(|| format!("creating {}/images", root.display()))?;
         fs::create_dir_all(root.join("tracks"))
             .with_context(|| format!("creating {}/tracks", root.display()))?;
+        fs::create_dir_all(root.join("lyrics"))
+            .with_context(|| format!("creating {}/lyrics", root.display()))?;
         Ok(Self {
             root,
             lock: Arc::new(Mutex::new(())),
         })
+    }
+
+    fn lyrics_path(&self, video_id: &str) -> (PathBuf, [u8; 32]) {
+        let mut hasher = Sha256::new();
+        hasher.update(video_id.as_bytes());
+        let hash: [u8; 32] = hasher.finalize().into();
+        (
+            self.root.join("lyrics").join(format!("{video_id}.json")),
+            hash,
+        )
+    }
+
+    /// Read a cached lyrics JSON payload, or `None` if absent/expired.
+    pub fn get_lyrics(&self, video_id: &str) -> Result<Option<String>> {
+        let (path, hash) = self.lyrics_path(video_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        if Self::is_expired(&path, &hash) {
+            let _ = fs::remove_file(&path);
+            return Ok(None);
+        }
+        let _ = touch(&path);
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        Ok(Some(content))
+    }
+
+    /// Persist a lyrics JSON payload. Overwrites any prior entry.
+    pub fn put_lyrics(&self, video_id: &str, json: &str) -> Result<()> {
+        if video_id.is_empty() {
+            return Ok(());
+        }
+        let (path, _) = self.lyrics_path(video_id);
+        fs::write(&path, json)
+            .with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
     }
 
     fn image_path(&self, url: &str) -> (PathBuf, [u8; 32]) {
@@ -166,7 +206,7 @@ impl Cache {
     pub async fn clear(&self) -> Result<u64> {
         let _guard = self.lock.lock().await;
         let mut freed = 0u64;
-        for sub in ["images", "tracks"] {
+        for sub in ["images", "tracks", "lyrics"] {
             let dir = self.root.join(sub);
             if !dir.exists() {
                 continue;

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -233,3 +233,68 @@ pub async fn remove_playlist_from_library(
         e.to_string()
     })
 }
+
+#[tauri::command]
+pub async fn get_upcoming_tracks(
+    video_id: String,
+    limit: Option<usize>,
+    app: AppHandle,
+    api: State<'_, YtmApi>,
+) -> Result<Vec<TrackInfo>, String> {
+    let limit = limit.unwrap_or(3).min(10);
+    tracing::info!(video_id = %video_id, limit, "browse::get_upcoming_tracks called");
+    let result = api
+        .get_upcoming_tracks(&app, &video_id, limit)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "browse::get_upcoming_tracks failed");
+            e.to_string()
+        })?;
+    tracing::info!(count = result.len(), "browse::get_upcoming_tracks done");
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn get_lyrics(
+    video_id: String,
+    artist: Option<String>,
+    title: Option<String>,
+    duration_secs: Option<f64>,
+    app: AppHandle,
+    api: State<'_, YtmApi>,
+    cache: State<'_, Cache>,
+) -> Result<Lyrics, String> {
+    tracing::info!(video_id = %video_id, "browse::get_lyrics called");
+
+    // Disk cache hit? Return immediately — no network round-trip, survives
+    // app restarts. The cache's 7d+jitter TTL handles freshness.
+    if let Ok(Some(raw)) = cache.get_lyrics(&video_id) {
+        if let Ok(cached) = serde_json::from_str::<Lyrics>(&raw) {
+            tracing::info!(video_id = %video_id, "browse::get_lyrics served from disk cache");
+            return Ok(cached);
+        }
+    }
+
+    let result = api
+        .get_lyrics(&app, &video_id, artist.as_deref(), title.as_deref(), duration_secs)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "browse::get_lyrics failed");
+            e.to_string()
+        })?;
+
+    // Persist only meaningful results. Empty stubs are left un-cached so a
+    // later probe (with better title cleaning or once LRCLIB re-indexes)
+    // can still populate the track.
+    let has_text = !result.text.trim().is_empty();
+    let has_lines = result.lines.as_ref().map_or(false, |l| !l.is_empty());
+    if has_text || has_lines {
+        if let Ok(json) = serde_json::to_string(&result) {
+            if let Err(e) = cache.put_lyrics(&video_id, &json) {
+                tracing::warn!(error = %e, "failed to persist lyrics cache");
+            }
+        }
+    }
+
+    Ok(result)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -129,6 +129,8 @@ pub fn run() {
             commands::browse::get_library_artists,
             commands::browse::save_playlist_to_library,
             commands::browse::remove_playlist_from_library,
+            commands::browse::get_lyrics,
+            commands::browse::get_upcoming_tracks,
             commands::cache::cache_fetch_image,
             commands::cache::cache_clear,
             commands::cache::cache_stats,

--- a/src-tauri/src/webview_bridge/api.rs
+++ b/src-tauri/src/webview_bridge/api.rs
@@ -51,27 +51,53 @@ pub async fn ytm_api_call(
                 }});
             }}
 
+            // Prefer YTM's own INNERTUBE_CONTEXT (pulled from ytcfg) so our
+            // requests match the ones YTM web makes. That's what unlocks the
+            // Elements-rendered timed lyrics on synced tracks — the minimal
+            // hand-crafted context we used before got the plain-text path only.
+            var ytctx = null;
+            try {{
+                if (window.ytcfg && typeof window.ytcfg.get === 'function') {{
+                    ytctx = window.ytcfg.get('INNERTUBE_CONTEXT');
+                }}
+                if (!ytctx && window.ytcfg && window.ytcfg.data_) {{
+                    ytctx = window.ytcfg.data_.INNERTUBE_CONTEXT;
+                }}
+            }} catch (e) {{ ytctx = null; }}
+            var ytApiKey = null;
+            try {{
+                if (window.ytcfg && typeof window.ytcfg.get === 'function') {{
+                    ytApiKey = window.ytcfg.get('INNERTUBE_API_KEY');
+                }}
+                if (!ytApiKey && window.ytcfg && window.ytcfg.data_) {{
+                    ytApiKey = window.ytcfg.data_.INNERTUBE_API_KEY;
+                }}
+            }} catch (e) {{ ytApiKey = null; }}
+
             makeAuth().then(function(auth) {{
                 var headers = {{
                     'Content-Type': 'application/json',
                     'X-Origin': 'https://music.youtube.com',
                     'X-Goog-AuthUser': '0',
+                    'X-YouTube-Client-Name': (ytctx && ytctx.client && ytctx.client.clientName === 'WEB_REMIX') ? '67' : '67',
+                    'X-YouTube-Client-Version': (ytctx && ytctx.client && ytctx.client.clientVersion) || '1.20250407.01.00',
                 }};
                 if (auth) headers['Authorization'] = auth;
-                return fetch('https://music.youtube.com/youtubei/v1/{endpoint}?prettyPrint=false', {{
+                var url = 'https://music.youtube.com/youtubei/v1/{endpoint}?prettyPrint=false';
+                if (ytApiKey) url += '&key=' + encodeURIComponent(ytApiKey);
+                var ctx = ytctx || {{
+                    client: {{
+                        clientName: 'WEB_REMIX',
+                        clientVersion: '1.20250407.01.00',
+                        hl: navigator.language || 'en',
+                        gl: 'US'
+                    }}
+                }};
+                return fetch(url, {{
                     method: 'POST',
                     credentials: 'include',
                     headers: headers,
-                    body: JSON.stringify(Object.assign({{
-                        context: {{
-                            client: {{
-                                clientName: 'WEB_REMIX',
-                                clientVersion: '1.20250407.01.00',
-                                hl: navigator.language || 'en',
-                                gl: 'US'
-                            }}
-                        }}
-                    }}, {body_json}))
+                    body: JSON.stringify(Object.assign({{ context: ctx }}, {body_json}))
                 }});
             }})
             .then(function(r) {{ return r.text(); }})

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -220,6 +220,427 @@ impl YtmApi {
             .map_err(anyhow::Error::msg)?;
         check_like_response(&raw, "removelike")
     }
+
+    /// Fetch lyrics for a track. Two-step flow: `next` with the videoId
+    /// surfaces a tabs list; the "Lyrics" tab carries a `browseId` that
+    /// returns the actual lyrics text via a second `browse` call.
+    ///
+    /// When YTM ships only plain text (the common case), a fallback hop to
+    /// the public LRCLIB database supplies per-line timings — required for
+    /// the highlight-and-scroll-with-playback UX.
+    pub async fn get_lyrics(
+        &self,
+        app: &AppHandle,
+        video_id: &str,
+        artist: Option<&str>,
+        title: Option<&str>,
+        duration_secs: Option<f64>,
+    ) -> anyhow::Result<Lyrics> {
+        let next_body = serde_json::json!({ "videoId": video_id }).to_string();
+        let next_raw = ytm_api_call(app, "next", &next_body)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        let next_data: Value = serde_json::from_str(&next_raw)?;
+        let browse_id = extract_lyrics_browse_id(&next_data).ok_or_else(|| {
+            anyhow::anyhow!("YTM did not expose a lyrics tab for this track")
+        })?;
+
+        let browse_body = serde_json::json!({ "browseId": browse_id }).to_string();
+        let browse_raw = ytm_api_call(app, "browse", &browse_body)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        let browse_data: Value = serde_json::from_str(&browse_raw)?;
+        let mut lyrics = parse_lyrics(&browse_data);
+
+        // YTM already shipped synced lines — use them and skip external sources.
+        if lyrics.lines.as_ref().map_or(false, |l| !l.is_empty()) {
+            return Ok(lyrics);
+        }
+
+        // Trust YTM's "no lyrics" verdict (empty text + no lines). That path
+        // covers instrumentals, karaoke versions, uploaded covers that lack
+        // lyrics, etc. Falling through to LRCLIB/NetEase here would match
+        // the vocal original by title and paste its lyrics onto a piano /
+        // instrumental rendition — false positive.
+        let has_plain_text = !lyrics.text.trim().is_empty();
+        if !has_plain_text {
+            tracing::info!(
+                video_id,
+                "YTM reported no lyrics — skipping external sync lookup (likely instrumental)"
+            );
+            return Ok(lyrics);
+        }
+
+        if let (Some(artist), Some(title)) = (artist, title) {
+            let clean_artist = clean_query_field(artist);
+            let clean_title = clean_query_field(title);
+
+            // Race LRCLIB and NetEase in parallel. Whichever returns synced
+            // lyrics first wins; `None` results wait for the other source
+            // before giving up. Different sources win on different catalogs
+            // (LRCLIB for Western, NetEase for CJK), so racing halves the
+            // typical wait instead of trying them one after the other.
+            let artist_l = clean_artist.clone();
+            let title_l = clean_title.clone();
+            let vid_l = video_id.to_string();
+            let lrc_fut = async move {
+                match fetch_lrclib_synced(&artist_l, &title_l, duration_secs).await {
+                    Ok(Some(body)) => Some((body, "LRCLIB")),
+                    Ok(None) => {
+                        tracing::info!(video_id = %vid_l, "LRCLIB had no synced lyrics");
+                        None
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "LRCLIB fetch failed");
+                        None
+                    }
+                }
+            };
+
+            let artist_n = clean_artist.clone();
+            let title_n = clean_title.clone();
+            let vid_n = video_id.to_string();
+            let ne_fut = async move {
+                match fetch_netease_synced(&artist_n, &title_n).await {
+                    Ok(Some(body)) => Some((body, "NetEase")),
+                    Ok(None) => {
+                        tracing::info!(video_id = %vid_n, "NetEase had no synced lyrics");
+                        None
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "NetEase fetch failed");
+                        None
+                    }
+                }
+            };
+
+            tokio::pin!(lrc_fut, ne_fut);
+            let mut lrc_done = false;
+            let mut ne_done = false;
+            let mut winner: Option<(String, &'static str)> = None;
+
+            while winner.is_none() && !(lrc_done && ne_done) {
+                tokio::select! {
+                    r = &mut lrc_fut, if !lrc_done => {
+                        lrc_done = true;
+                        if r.is_some() { winner = r; }
+                    }
+                    r = &mut ne_fut, if !ne_done => {
+                        ne_done = true;
+                        if r.is_some() { winner = r; }
+                    }
+                }
+            }
+
+            if let Some((body, source_name)) = winner {
+                if apply_synced_lrc(&mut lyrics, &body, source_name) {
+                    return Ok(lyrics);
+                }
+            }
+        }
+
+        Ok(lyrics)
+    }
+
+    /// Fetch the upcoming tracks for a given videoId by calling YTM's
+    /// `next` endpoint and parsing its queue panel. Used to warm the
+    /// lyrics cache for songs the user will play in a few seconds.
+    pub async fn get_upcoming_tracks(
+        &self,
+        app: &AppHandle,
+        video_id: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<TrackInfo>> {
+        let body = serde_json::json!({ "videoId": video_id }).to_string();
+        let raw = ytm_api_call(app, "next", &body)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        let data: Value = serde_json::from_str(&raw)?;
+        Ok(extract_upcoming_tracks(&data, video_id, limit))
+    }
+}
+
+/// Mutate `lyrics` in-place with parsed LRC data from an external source.
+/// Returns `true` when timed lines were successfully adopted.
+fn apply_synced_lrc(lyrics: &mut Lyrics, lrc: &str, source_name: &str) -> bool {
+    let parsed = parse_lrc(lrc);
+    if parsed.is_empty() {
+        return false;
+    }
+    lyrics.text = parsed
+        .iter()
+        .map(|l| l.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    lyrics.lines = Some(parsed);
+    let existing = lyrics.source.take();
+    lyrics.source = Some(match existing {
+        Some(s) if !s.is_empty() => format!("{s} · Synced by {source_name}"),
+        _ => format!("Synced by {source_name}"),
+    });
+    true
+}
+
+/// Strip common YouTube-title noise that kills exact-match lookups on
+/// LRCLIB / NetEase: parenthesized "Official MV" markers, bracketed tags,
+/// full-width Chinese brackets, and a trailing `- My Secret` translation.
+fn clean_query_field(s: &str) -> String {
+    // Noise tokens we strip when they appear inside any bracket pair. Match
+    // case-insensitively; any bracket whose lowercased inner text contains
+    // one of these tokens gets dropped wholesale.
+    const NOISE_TOKENS: &[&str] = &[
+        "official", "mv", "music video", "audio", "lyric", "visualizer",
+        "hd", "hq", "remix", "cover", "live", "版", "版本",
+    ];
+
+    let noise_pairs: &[(char, char)] = &[('(', ')'), ('[', ']'), ('【', '】'), ('〈', '〉')];
+    let mut out = s.to_string();
+
+    for (open, close) in noise_pairs {
+        out = strip_noise_brackets(&out, *open, *close, NOISE_TOKENS);
+    }
+
+    // Cut at " - " dash-tail (translations, "- My Secret", etc.) only when
+    // the part before it is meaningfully long.
+    if let Some(idx) = out.find(" - ") {
+        let head = &out[..idx];
+        if head.trim().chars().count() >= 2 {
+            out = head.to_string();
+        }
+    }
+
+    // Collapse internal whitespace runs so the remote query encodes cleanly.
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Remove every `open..close` pair whose contents contain any of the given
+/// lowercase noise tokens. Tolerant of mismatched / unbalanced brackets
+/// (just returns the tail unchanged when it can't find a close).
+fn strip_noise_brackets(
+    s: &str,
+    open: char,
+    close: char,
+    noise_tokens: &[&str],
+) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(pos) = rest.find(open) {
+        out.push_str(&rest[..pos]);
+        let after_open = &rest[pos + open.len_utf8()..];
+        let Some(end_off) = after_open.find(close) else {
+            // No closing bracket; keep the open char and everything else.
+            out.push(open);
+            out.push_str(after_open);
+            return out;
+        };
+        let inner = &after_open[..end_off];
+        let lower = inner.to_lowercase();
+        let is_noise = noise_tokens.iter().any(|t| lower.contains(t));
+        if !is_noise {
+            // Keep non-noise brackets verbatim.
+            out.push(open);
+            out.push_str(inner);
+            out.push(close);
+        }
+        rest = &after_open[end_off + close.len_utf8()..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Ask LRCLIB (https://lrclib.net) for synced LRC-format lyrics. Returns the
+/// raw LRC body on success, `None` when LRCLIB has no match, `Err` on
+/// transport failure. LRCLIB is a free, open, community-maintained database
+/// of synced lyrics keyed by artist/track/duration.
+async fn fetch_lrclib_synced(
+    artist: &str,
+    title: &str,
+    duration_secs: Option<f64>,
+) -> anyhow::Result<Option<String>> {
+    // LRCLIB can take 5-8s to respond for CJK/less-indexed queries. A
+    // tight timeout is why Chinese tracks were falling through to NetEase.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()?;
+    let mut query: Vec<(&str, String)> = vec![
+        ("artist_name", artist.to_string()),
+        ("track_name", title.to_string()),
+    ];
+    if let Some(d) = duration_secs.filter(|d| *d > 0.0) {
+        query.push(("duration", (d.round() as u64).to_string()));
+    }
+
+    let resp = client
+        .get("https://lrclib.net/api/get")
+        .query(&query)
+        .header(
+            "User-Agent",
+            "VibeYTM/0.9.0 (https://github.com/dongli/VibeYTM)",
+        )
+        .send()
+        .await?;
+
+    if resp.status().as_u16() == 404 {
+        return Ok(None);
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!("LRCLIB returned HTTP {}", resp.status());
+    }
+
+    let body: Value = resp.json().await?;
+    // LRCLIB returns instrumental tracks with syncedLyrics=null, plainLyrics="".
+    if body.get("instrumental").and_then(|v| v.as_bool()).unwrap_or(false) {
+        return Ok(None);
+    }
+    let synced = body.get("syncedLyrics").and_then(|v| v.as_str()).unwrap_or("");
+    if synced.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(synced.to_string()))
+}
+
+/// Ask NetEase Cloud Music for synced LRC-format lyrics. Does a two-call
+/// lookup: search by "artist title" to find a song id, then fetch that
+/// song's lyrics. NetEase has excellent coverage for Mandopop, Cantopop,
+/// K-pop, J-pop, and a growing Western catalog. Free, no auth required.
+async fn fetch_netease_synced(artist: &str, title: &str) -> anyhow::Result<Option<String>> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(12))
+        .build()?;
+
+    // Step 1: search. `s` is the query, `type=1` selects song results.
+    let query = format!("{artist} {title}");
+    let search_resp = client
+        .get("https://music.163.com/api/search/get")
+        .query(&[("s", query.as_str()), ("type", "1"), ("limit", "5")])
+        .header("Referer", "https://music.163.com")
+        .header(
+            "User-Agent",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 \
+             (KHTML, like Gecko) Version/16.0 Safari/605.1.15",
+        )
+        .send()
+        .await?;
+
+    if !search_resp.status().is_success() {
+        anyhow::bail!("NetEase search HTTP {}", search_resp.status());
+    }
+    let search_body: Value = search_resp.json().await?;
+    let Some(songs) = search_body.pointer("/result/songs").and_then(|v| v.as_array()) else {
+        return Ok(None);
+    };
+
+    // Pick the first candidate whose title loosely matches — NetEase's
+    // search is forgiving so the top hit is usually right, but we defend
+    // against karaoke / cover false positives by checking the returned name.
+    let want_title = title.to_lowercase();
+    let picked_id = songs
+        .iter()
+        .find_map(|s| {
+            let name = s.get("name").and_then(|v| v.as_str()).unwrap_or("").to_lowercase();
+            let id = s.get("id").and_then(|v| v.as_u64())?;
+            if name.contains(&want_title) || want_title.contains(&name) {
+                Some(id)
+            } else {
+                None
+            }
+        })
+        .or_else(|| songs.first().and_then(|s| s.get("id")).and_then(|v| v.as_u64()));
+
+    let Some(song_id) = picked_id else {
+        return Ok(None);
+    };
+
+    // Step 2: fetch lyrics. `lv=1` asks for original LRC, `tv=-1` suppresses
+    // the translation track (we render the native text).
+    let lyric_resp = client
+        .get("https://music.163.com/api/song/lyric")
+        .query(&[
+            ("id", song_id.to_string().as_str()),
+            ("lv", "1"),
+            ("tv", "-1"),
+        ])
+        .header("Referer", "https://music.163.com")
+        .send()
+        .await?;
+
+    if !lyric_resp.status().is_success() {
+        anyhow::bail!("NetEase lyric HTTP {}", lyric_resp.status());
+    }
+    let body: Value = lyric_resp.json().await?;
+    let lrc = body
+        .pointer("/lrc/lyric")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty() && s.contains('['));
+    Ok(lrc.map(str::to_string))
+}
+
+/// Parse an LRC-format string into timed lines. LRC supports multiple
+/// timestamps per line (for repeats) and `[mm:ss.xx]` or `[mm:ss]` forms.
+/// Metadata headers like `[ar:Artist]` are treated as non-numeric and skipped.
+fn parse_lrc(lrc: &str) -> Vec<LyricLine> {
+    let mut out: Vec<LyricLine> = Vec::new();
+    for raw in lrc.lines() {
+        let mut stamps: Vec<u64> = Vec::new();
+        let mut rest = raw;
+        loop {
+            let Some(open) = rest.find('[') else { break; };
+            if open != 0 {
+                break;
+            }
+            let Some(close) = rest[open + 1..].find(']') else { break; };
+            let inner = &rest[open + 1..open + 1 + close];
+            if let Some(ms) = parse_lrc_timestamp(inner) {
+                stamps.push(ms);
+            }
+            rest = &rest[open + 1 + close + 1..];
+        }
+        if stamps.is_empty() {
+            continue;
+        }
+        let text = rest.trim().to_string();
+        for start_ms in stamps {
+            out.push(LyricLine {
+                start_ms,
+                end_ms: None,
+                text: text.clone(),
+            });
+        }
+    }
+    out.sort_by_key(|l| l.start_ms);
+
+    // Fill end_ms from the next line's start so the UI can render line
+    // durations if it wants. Keeps the last line open-ended.
+    for i in 0..out.len().saturating_sub(1) {
+        let next = out[i + 1].start_ms;
+        out[i].end_ms = Some(next);
+    }
+
+    out
+}
+
+/// Parse an LRC-style timestamp. Accepts `mm:ss`, `mm:ss.xx`, `mm:ss.xxx`.
+/// Returns milliseconds; `None` for non-numeric (e.g. metadata keys).
+fn parse_lrc_timestamp(s: &str) -> Option<u64> {
+    let (mins_str, rest) = s.split_once(':')?;
+    let mins: u64 = mins_str.trim().parse().ok()?;
+    let (secs_str, frac_str) = match rest.split_once('.') {
+        Some((a, b)) => (a, Some(b)),
+        None => (rest, None),
+    };
+    let secs: u64 = secs_str.trim().parse().ok()?;
+    let frac_ms: u64 = match frac_str {
+        Some(f) => {
+            // "5" → 500 ms, "50" → 500 ms, "500" → 500 ms, "1234" → 123 ms
+            let mut digits: String = f.chars().take(3).collect();
+            while digits.len() < 3 {
+                digits.push('0');
+            }
+            digits.parse().ok()?
+        }
+        None => 0,
+    };
+    Some(mins * 60_000 + secs * 1_000 + frac_ms)
 }
 
 /// YTM returns a minimal JSON body on success (responseContext + actions).
@@ -1663,6 +2084,225 @@ fn parse_playlist_from_two_row(two_row: &Value) -> Option<PlaylistSummary> {
         artwork_url,
         track_count,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Lyrics
+// ---------------------------------------------------------------------------
+
+/// Walk the watch-next tab list and return the `browseId` whose tab title
+/// mentions lyrics. Title matching is case-insensitive so non-English locales
+/// don't silently drop to `None` — YTM localizes the tab label but keeps the
+/// lyrics browse IDs identifiable on the lyrics-tab position (second tab).
+fn extract_lyrics_browse_id(data: &Value) -> Option<String> {
+    let tabs = data
+        .pointer("/contents/singleColumnMusicWatchNextResultsRenderer/tabbedRenderer/watchNextTabbedResultsRenderer/tabs")?
+        .as_array()?;
+
+    for tab in tabs {
+        let Some(renderer) = tab.get("tabRenderer") else { continue; };
+        let title = renderer
+            .get("title")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_lowercase();
+        let Some(browse_id) = renderer
+            .pointer("/endpoint/browseEndpoint/browseId")
+            .and_then(|v| v.as_str())
+        else {
+            continue;
+        };
+        if title.contains("lyric") || browse_id.starts_with("MPLYt") {
+            return Some(browse_id.to_string());
+        }
+    }
+    None
+}
+
+/// Pull the next up-to-`limit` tracks from the `next`-response queue panel.
+/// Skips the entry matching `skip_video_id` so the current track isn't
+/// returned as its own upcoming.
+fn extract_upcoming_tracks(data: &Value, skip_video_id: &str, limit: usize) -> Vec<TrackInfo> {
+    let contents = data
+        .pointer("/contents/singleColumnMusicWatchNextResultsRenderer/tabbedRenderer/watchNextTabbedResultsRenderer/tabs/0/tabRenderer/content/musicQueueRenderer/content/playlistPanelRenderer/contents")
+        .and_then(|v| v.as_array());
+    let Some(contents) = contents else {
+        return Vec::new();
+    };
+
+    let mut out: Vec<TrackInfo> = Vec::new();
+    for entry in contents {
+        if out.len() >= limit {
+            break;
+        }
+        // YTM wraps each queue entry as either:
+        //   { playlistPanelVideoRenderer: { ... } }                 (older)
+        //   { playlistPanelVideoWrapperRenderer:
+        //       { primaryRenderer: { playlistPanelVideoRenderer: { ... } } } } (current)
+        let r = entry
+            .get("playlistPanelVideoRenderer")
+            .or_else(|| entry.pointer("/playlistPanelVideoWrapperRenderer/primaryRenderer/playlistPanelVideoRenderer"));
+        let Some(r) = r else { continue };
+        let video_id = r
+            .get("videoId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if video_id.is_empty() || video_id == skip_video_id {
+            continue;
+        }
+        let title = r
+            .pointer("/title/runs")
+            .map(runs_text)
+            .unwrap_or_default();
+        let artist = r
+            .pointer("/longBylineText/runs")
+            .or_else(|| r.pointer("/shortBylineText/runs"))
+            .map(runs_text)
+            .unwrap_or_default();
+        let duration_secs = r
+            .pointer("/lengthText/runs/0/text")
+            .and_then(|v| v.as_str())
+            .map(parse_duration_text)
+            .unwrap_or(0.0);
+        let artwork_url = r
+            .pointer("/thumbnail/thumbnails")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.last())
+            .and_then(|t| t.get("url"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        out.push(TrackInfo {
+            video_id,
+            title,
+            artist,
+            artist_id: None,
+            album: String::new(),
+            album_id: None,
+            artwork_url,
+            duration_secs,
+        });
+    }
+    out
+}
+
+/// Extract lyrics from a YTM `browse` response against a lyrics browseId.
+///
+/// YTM ships lyrics in two possible renderers depending on the track:
+///   * `musicDescriptionShelfRenderer` — plain text (licensed, no timing)
+///   * `elementRenderer … timedLyricsModel` — per-line synced lyrics
+///     (YTM's own, available on a growing catalog)
+///
+/// We prefer timed lyrics when present; otherwise fall back to plain text.
+fn parse_lyrics(data: &Value) -> Lyrics {
+    if let Some(timed) = parse_timed_lyrics(data) {
+        return timed;
+    }
+
+    let section = data
+        .pointer("/contents/sectionListRenderer/contents")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first());
+
+    let shelf = section.and_then(|s| s.get("musicDescriptionShelfRenderer"));
+
+    let text = shelf
+        .and_then(|s| s.pointer("/description/runs"))
+        .map(runs_text)
+        .unwrap_or_default();
+
+    let source = shelf
+        .and_then(|s| s.pointer("/footer/runs"))
+        .map(runs_text)
+        .filter(|s| !s.is_empty());
+
+    Lyrics {
+        text,
+        source,
+        lines: None,
+    }
+}
+
+/// Attempt to extract synced lyrics from YTM's elementRenderer-based timed
+/// lyrics payload. Returns `None` when the track has no timed data — the
+/// caller falls back to plain text.
+fn parse_timed_lyrics(data: &Value) -> Option<Lyrics> {
+    // Path shape emitted by YTM's Elements runtime for timed lyrics.
+    let timed = data
+        .pointer("/contents/elementRenderer/newElement/type/componentType/model/timedLyricsModel/lyricsData")
+        .or_else(|| {
+            // Some responses wrap the element under a sectionListRenderer list.
+            data.pointer("/contents/sectionListRenderer/contents")
+                .and_then(|v| v.as_array())
+                .and_then(|arr| {
+                    arr.iter().find_map(|entry| {
+                        entry.pointer(
+                            "/elementRenderer/newElement/type/componentType/model/timedLyricsModel/lyricsData",
+                        )
+                    })
+                })
+        })?;
+
+    let entries = timed.get("timedLyricsData").and_then(|v| v.as_array())?;
+    if entries.is_empty() {
+        return None;
+    }
+
+    let mut lines: Vec<LyricLine> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let text = entry
+            .get("lyricLine")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let start_ms = entry
+            .pointer("/cueRange/startTimeMilliseconds")
+            .and_then(parse_ms)
+            .unwrap_or(0);
+        let end_ms = entry
+            .pointer("/cueRange/endTimeMilliseconds")
+            .and_then(parse_ms);
+
+        if text.is_empty() {
+            continue;
+        }
+        lines.push(LyricLine {
+            start_ms,
+            end_ms,
+            text,
+        });
+    }
+
+    if lines.is_empty() {
+        return None;
+    }
+
+    let text = lines
+        .iter()
+        .map(|l| l.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let source = timed
+        .get("sourceMessage")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty());
+
+    Some(Lyrics {
+        text,
+        source,
+        lines: Some(lines),
+    })
+}
+
+/// YTM stringifies millisecond timings; accept both numeric and string forms.
+fn parse_ms(v: &Value) -> Option<u64> {
+    if let Some(n) = v.as_u64() {
+        return Some(n);
+    }
+    v.as_str().and_then(|s| s.parse::<u64>().ok())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/ytm_api/types.rs
+++ b/src-tauri/src/ytm_api/types.rs
@@ -85,3 +85,28 @@ pub enum ShelfContent {
     Songs(Vec<TrackInfo>),
     Artists(Vec<ArtistSummary>),
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Lyrics {
+    /// Lyrics text with line breaks preserved. Empty when YTM returned a
+    /// lyrics tab but no content (e.g. "Lyrics not available" placeholder).
+    pub text: String,
+    /// Attribution line YTM renders below the lyrics ("Source: ...").
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Per-line timing when YTM ships synced lyrics for the track. `None`
+    /// when only plain text was returned — the UI then falls back to a
+    /// static, non-highlighting view.
+    #[serde(default)]
+    pub lines: Option<Vec<LyricLine>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LyricLine {
+    pub start_ms: u64,
+    #[serde(default)]
+    pub end_ms: Option<u64>,
+    pub text: String,
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ const App: FC = () => {
   const isLoggedIn = loginState === true || loginOverride;
   const [currentPath, setCurrentPath] = useState('home');
   const [isNowPlayingOpen, setIsNowPlayingOpen] = useState(false);
+  const [isLyricsOpen, setIsLyricsOpen] = useState(false);
   const [viewingPlaylist, setViewingPlaylist] = useState<ViewingPlaylist | null>(null);
   const [pendingSearchQuery, setPendingSearchQuery] = useState<string | null>(null);
   // Flips true once the Home page has finished its first real render (or we
@@ -51,7 +52,22 @@ const App: FC = () => {
     const now = Date.now();
     if (now - lastToggleAtRef.current < 450) return;
     lastToggleAtRef.current = now;
-    setIsNowPlayingOpen((prev) => !prev);
+    setIsNowPlayingOpen((prev) => {
+      // Closing the overlay also tears down the lyrics view — otherwise the
+      // next open would flash the lyrics layout before the user asked for it.
+      if (prev) setIsLyricsOpen(false);
+      return !prev;
+    });
+  }, []);
+
+  // Lyrics button opens the Now Playing page if it isn't already, then flips
+  // the lyrics view on/off within it.
+  const toggleLyrics = useCallback(() => {
+    setIsLyricsOpen((prev) => {
+      const next = !prev;
+      if (next) setIsNowPlayingOpen(true);
+      return next;
+    });
   }, []);
 
   const openPlaylistDetail = useCallback((playlistId: string) => {
@@ -166,6 +182,8 @@ const App: FC = () => {
       }}
       nowPlayingOpen={isNowPlayingOpen}
       onToggleNowPlaying={toggleNowPlaying}
+      lyricsOpen={isLyricsOpen}
+      onToggleLyrics={toggleLyrics}
     >
       {/*
         The underlying page (home/search/explore/library/settings) stays

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,68 @@
+import { type FC, type ReactNode } from 'react';
+
+const Spinner: FC<{ size?: number }> = ({ size = 40 }) => (
+  <div
+    role="status"
+    aria-label="Loading"
+    style={{
+      width: size,
+      height: size,
+      borderRadius: '50%',
+      border: '3px solid var(--color-surface-3)',
+      borderTopColor: 'var(--color-accent)',
+      animation: 'vibeytm-spin 0.9s linear infinite',
+    }}
+  />
+);
+
+export const LoadingSpinner: FC = () => (
+  <section
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '100%',
+      width: '100%',
+    }}
+  >
+    <Spinner />
+  </section>
+);
+
+interface ReloadOverlayProps {
+  children: ReactNode;
+}
+
+// Keeps previously-rendered content visible but blurred while a refetch is
+// in flight, with a centered spinner on top. Use when re-fetching data the
+// user has already seen — avoids the content-vanishing flash caused by
+// swapping in a "Loading…" placeholder.
+export const ReloadOverlay: FC<ReloadOverlayProps> = ({ children }) => (
+  <div style={{ position: 'relative', height: '100%', width: '100%' }}>
+    <div
+      aria-hidden
+      style={{
+        height: '100%',
+        width: '100%',
+        filter: 'blur(10px)',
+        pointerEvents: 'none',
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </div>
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'oklch(10% 0.005 270 / 0.35)',
+        pointerEvents: 'none',
+      }}
+    >
+      <Spinner />
+    </div>
+  </div>
+);

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -8,6 +8,8 @@ interface AppShellProps {
   onNavigate: (path: string) => void;
   nowPlayingOpen: boolean;
   onToggleNowPlaying: () => void;
+  lyricsOpen: boolean;
+  onToggleLyrics: () => void;
   children: ReactNode;
 }
 
@@ -16,6 +18,8 @@ export const AppShell: FC<AppShellProps> = ({
   onNavigate,
   nowPlayingOpen,
   onToggleNowPlaying,
+  lyricsOpen,
+  onToggleLyrics,
   children,
 }) => (
   <div
@@ -59,8 +63,14 @@ export const AppShell: FC<AppShellProps> = ({
     <PlayerBar
       onToggleNowPlaying={onToggleNowPlaying}
       nowPlayingOpen={nowPlayingOpen}
+      lyricsOpen={lyricsOpen}
+      onToggleLyrics={onToggleLyrics}
     />
 
-    <NowPlaying isOpen={nowPlayingOpen} onClose={onToggleNowPlaying} />
+    <NowPlaying
+      isOpen={nowPlayingOpen}
+      onClose={onToggleNowPlaying}
+      showLyrics={lyricsOpen}
+    />
   </div>
 );

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -1,6 +1,7 @@
-import { type FC, type ReactNode } from 'react';
+import { type FC, type ReactNode, useEffect } from 'react';
 import { usePlayerState } from '../../hooks/usePlayerState';
-import { playerApi } from '../../lib/ipc';
+import { useLyrics, preloadLyrics } from '../../hooks/useLyrics';
+import { browseApi, playerApi } from '../../lib/ipc';
 import type { RepeatMode } from '../../lib/types';
 import { CachedImage } from '../CachedImage';
 import { MarqueeText } from '../MarqueeText';
@@ -20,6 +21,8 @@ function pickArtwork(track: { artworkUrl?: string | null; videoId?: string }): s
 interface PlayerBarProps {
   onToggleNowPlaying?: () => void;
   nowPlayingOpen?: boolean;
+  onToggleLyrics?: () => void;
+  lyricsOpen?: boolean;
 }
 
 const formatTime = (secs: number): string => {
@@ -117,10 +120,62 @@ const NEXT_REPEAT_MODE: Record<RepeatMode, RepeatMode> = {
 export const PlayerBar: FC<PlayerBarProps> = ({
   onToggleNowPlaying,
   nowPlayingOpen = false,
+  onToggleLyrics,
+  lyricsOpen = false,
 }) => {
   const state = usePlayerState();
   const { track, status, positionSecs, volume, isShuffled, repeatMode, isLiked, applyOptimistic, markSeek } = state;
   const isPlaying = status === 'playing';
+
+  // Preload lyrics for the next two upcoming tracks so the LRC panel opens
+  // instantly when the user skips forward. YTM's upcoming queue isn't in
+  // our PlayerState — it lives in the `next` endpoint's playlist panel —
+  // so we ask the backend to fetch it for the current track, then fire
+  // preloadLyrics on each result. De-duped by the shared useLyrics cache.
+  const currentVideoId = track?.videoId;
+  useEffect(() => {
+    if (!currentVideoId) return;
+    let cancelled = false;
+    browseApi
+      .getUpcomingTracks(currentVideoId, 3)
+      .then((tracks) => {
+        if (cancelled) return;
+        for (const t of tracks.slice(0, 2)) {
+          if (!t.videoId || t.videoId === currentVideoId) continue;
+          preloadLyrics({
+            videoId: t.videoId,
+            artist: t.artist,
+            title: t.title,
+            durationSecs: t.durationSecs,
+          });
+        }
+      })
+      .catch(() => {
+        // Preload is best-effort — a failed upcoming-tracks lookup just
+        // means lyrics won't be warm when the user skips. Safe to swallow.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVideoId]);
+  // Pre-probe lyrics as soon as a track loads. `immediate=true` skips the
+  // track-change debounce so the fetch starts the instant playback begins —
+  // by the time the user clicks LRC, the result is usually ready (served
+  // from disk cache on a second visit, or already in-flight from the
+  // parallel LRCLIB + NetEase race on a first visit).
+  const { status: lyricsAvailability } = useLyrics(
+    track
+      ? {
+          videoId: track.videoId,
+          artist: track.artist,
+          title: track.title,
+          durationSecs: track.durationSecs,
+        }
+      : null,
+    true,
+    true,
+  );
+  const lyricsMissing = lyricsAvailability === 'missing';
 
   const handleTogglePlay = () => {
     // Optimistic flip — instant UI feedback. Backend's next event reconciles.
@@ -425,6 +480,49 @@ export const PlayerBar: FC<PlayerBarProps> = ({
             }}
           />
         </div>
+
+        {onToggleLyrics && track && (
+          <button
+            onClick={onToggleLyrics}
+            aria-label={lyricsOpen ? 'Hide lyrics' : 'Show lyrics'}
+            aria-pressed={lyricsOpen}
+            title={lyricsMissing ? 'No lyrics for this track' : undefined}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 'var(--text-xs)',
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              color: lyricsOpen ? 'var(--color-accent)' : 'var(--color-text-tertiary)',
+              // Always clickable. Dim the icon slightly when we know the
+              // track has no lyrics so the state is still communicated,
+              // but let the user open the panel to see the "No lyrics"
+              // message themselves.
+              opacity: lyricsMissing && !lyricsOpen ? 0.55 : 1,
+              padding: 'var(--space-1) var(--space-2)',
+              borderRadius: 'var(--radius-sm)',
+              transition: `color var(--duration-fast) var(--ease-out),
+                           transform var(--duration-fast) var(--ease-out),
+                           opacity var(--duration-fast) var(--ease-out)`,
+              cursor: 'pointer',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.transform = 'scale(1.1)';
+              if (!lyricsOpen) {
+                e.currentTarget.style.color = 'var(--color-text-primary)';
+              }
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.transform = 'scale(1)';
+              if (!lyricsOpen) {
+                e.currentTarget.style.color = 'var(--color-text-tertiary)';
+              }
+            }}
+          >
+            LRC
+          </button>
+        )}
 
         {onToggleNowPlaying && (
           <button

--- a/src/components/pages/ExplorePage.tsx
+++ b/src/components/pages/ExplorePage.tsx
@@ -4,6 +4,7 @@ import { browseApi, playFirstFromPlaylist } from '../../lib/ipc';
 import { ShelfRow } from '../browse/ShelfRow';
 import { AlbumCard } from '../browse/AlbumCard';
 import { SongRow } from '../browse/SongRow';
+import { LoadingSpinner, ReloadOverlay } from '../LoadingOverlay';
 
 interface ExplorePageProps {
   onOpenPlaylist?: (playlistId: string) => void;
@@ -50,21 +51,10 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
     fetchExplore();
   }, [fetchExplore]);
 
-  if (isLoading) {
-    return (
-      <section
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          color: 'var(--color-text-tertiary)',
-          fontSize: 'var(--text-base)',
-        }}
-      >
-        Loading...
-      </section>
-    );
+  const isReloading = isLoading || isRefreshing;
+
+  if (isLoading && shelves.length === 0) {
+    return <LoadingSpinner />;
   }
 
   if (error) {
@@ -105,7 +95,7 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
     );
   }
 
-  return (
+  const content = (
     <section
       style={{
         padding: '0 var(--space-6) var(--space-8)',
@@ -207,6 +197,12 @@ export const ExplorePage: FC<ExplorePageProps> = ({ onOpenPlaylist }) => {
         </div>
       )}
     </section>
+  );
+
+  return isReloading && shelves.length > 0 ? (
+    <ReloadOverlay>{content}</ReloadOverlay>
+  ) : (
+    content
   );
 };
 

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { useTauriEvent } from '../../hooks/useTauriEvent';
 import { ShelfRow } from '../browse/ShelfRow';
 import { AlbumCard } from '../browse/AlbumCard';
 import { SongRow } from '../browse/SongRow';
+import { LoadingSpinner, ReloadOverlay } from '../LoadingOverlay';
 
 interface HomePageProps {
   onOpenPlaylist?: (playlistId: string) => void;
@@ -161,24 +162,11 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist, onReady }) => {
     };
   }, [activeMood]);
 
-  if (isLoading) {
-    return (
-      <section
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          color: 'var(--color-text-tertiary)',
-          fontSize: 'var(--text-base)',
-        }}
-      >
-        Loading...
-      </section>
-    );
+  if (isLoading && shelves.length === 0) {
+    return <LoadingSpinner />;
   }
 
-  return (
+  const content = (
     <section
       style={{
         padding: '0 var(--space-6) var(--space-8)',
@@ -335,6 +323,8 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist, onReady }) => {
         ))}
     </section>
   );
+
+  return isLoading ? <ReloadOverlay>{content}</ReloadOverlay> : content;
 };
 
 function renderShelfContent(

--- a/src/components/pages/LibraryPage.tsx
+++ b/src/components/pages/LibraryPage.tsx
@@ -8,6 +8,7 @@ import type {
 import { browseApi, playFirstFromPlaylist } from '../../lib/ipc';
 import { AlbumCard } from '../browse/AlbumCard';
 import { SongRow } from '../browse/SongRow';
+import { LoadingSpinner, ReloadOverlay } from '../LoadingOverlay';
 
 export type LibraryTab = 'playlists' | 'songs' | 'albums' | 'artists';
 
@@ -86,7 +87,17 @@ export const LibraryPage: FC<LibraryPageProps> = ({
     };
   }, [activeTab, refreshKey]);
 
-  return (
+  const currentTabHasData =
+    (activeTab === 'playlists' && playlists.length > 0) ||
+    (activeTab === 'songs' && songs.length > 0) ||
+    (activeTab === 'albums' && albums.length > 0) ||
+    (activeTab === 'artists' && artists.length > 0);
+
+  if (isLoading && !currentTabHasData) {
+    return <LoadingSpinner />;
+  }
+
+  const content = (
     <section
       style={{
         padding: '0 var(--space-6) var(--space-8)',
@@ -122,13 +133,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({
       </h1>
       </div>
 
-      {isLoading && (
-        <p style={{ fontSize: 'var(--text-base)', color: 'var(--color-text-tertiary)' }}>
-          Loading...
-        </p>
-      )}
-
-      {!isLoading && activeTab === 'playlists' && (
+      {activeTab === 'playlists' && (
         <>
           {playlists.length > 0 ? (
             <div
@@ -162,7 +167,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({
         </>
       )}
 
-      {!isLoading && activeTab === 'songs' && (
+      {activeTab === 'songs' && (
         <>
           {songs.length > 0 ? (
             <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -176,7 +181,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({
         </>
       )}
 
-      {!isLoading && activeTab === 'albums' && (
+      {activeTab === 'albums' && (
         <>
           {albums.length > 0 ? (
             <div
@@ -212,7 +217,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({
         </>
       )}
 
-      {!isLoading && activeTab === 'artists' && (
+      {activeTab === 'artists' && (
         <>
           {artists.length > 0 ? (
             <div
@@ -288,6 +293,8 @@ export const LibraryPage: FC<LibraryPageProps> = ({
       )}
     </section>
   );
+
+  return isLoading ? <ReloadOverlay>{content}</ReloadOverlay> : content;
 };
 
 const EmptyState: FC<{ label: string }> = ({ label }) => (

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -3,6 +3,7 @@ import type { PlaylistDetail } from '../../lib/types';
 import { browseApi, playerApi } from '../../lib/ipc';
 import { SongRow } from '../browse/SongRow';
 import { CachedImage } from '../CachedImage';
+import { LoadingSpinner } from '../LoadingOverlay';
 
 interface PlaylistDetailPageProps {
   playlistId: string;
@@ -111,21 +112,10 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
     };
   }, [playlistId, autoPlay]);
 
+  // PlaylistDetailPage resets `playlist` to null before each fetch, so there
+  // is no stale content to blur mid-load — keep the plain spinner here.
   if (isLoading) {
-    return (
-      <section
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          color: 'var(--color-text-tertiary)',
-          fontSize: 'var(--text-base)',
-        }}
-      >
-        Loading...
-      </section>
-    );
+    return <LoadingSpinner />;
   }
 
   if (error) {

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -408,18 +408,21 @@ export const SearchPage: FC<SearchPageProps> = ({
       </div>
       </div>
 
-      {isLoading && (
-        <p
-          style={{
-            fontSize: 'var(--text-base)',
-            color: 'var(--color-text-tertiary)',
-          }}
-        >
-          Searching...
-        </p>
-      )}
+      {/*
+        Results region wrapped in a relative container so a reload can blur
+        the previous results while a spinner overlays on top — instead of
+        wiping them to a "Searching…" placeholder.
+      */}
+      <div style={{ position: 'relative', minHeight: '200px' }}>
+      <div
+        style={{
+          filter: isLoading && results ? 'blur(10px)' : 'none',
+          pointerEvents: isLoading ? 'none' : 'auto',
+          transition: 'filter var(--duration-normal) var(--ease-out)',
+        }}
+      >
 
-      {!isLoading && !results && (
+      {!results && !isLoading && (
         <div
           style={{
             display: 'flex',
@@ -440,7 +443,7 @@ export const SearchPage: FC<SearchPageProps> = ({
       )}
 
       {/* ---------- Unified default view (no tab selected) ---------- */}
-      {!isLoading && results && activeCategory === null && (
+      {results && activeCategory === null && (
         <>
           {topAlbum && topAlbumPreview && previewTracks.length > 0 && topCoverReady && (
             <ShelfRow title="Top result">
@@ -570,7 +573,7 @@ export const SearchPage: FC<SearchPageProps> = ({
       )}
 
       {/* ---------- Tab-specific views ---------- */}
-      {!isLoading && results && activeCategory === 'Songs' && (
+      {results && activeCategory === 'Songs' && (
         <>
           {results.songs.length > 0 ? (
             <ShelfRow title="Songs">
@@ -586,7 +589,7 @@ export const SearchPage: FC<SearchPageProps> = ({
         </>
       )}
 
-      {!isLoading && results && activeCategory === 'Albums' && (
+      {results && activeCategory === 'Albums' && (
         <>
           {results.albums.length > 0 ? (
             <ShelfRow title="Albums">
@@ -624,7 +627,7 @@ export const SearchPage: FC<SearchPageProps> = ({
         </>
       )}
 
-      {!isLoading && results && activeCategory === 'Playlists' && (
+      {results && activeCategory === 'Playlists' && (
         <>
           {results.playlists.length > 0 ? (
             <ShelfRow title="Playlists">
@@ -660,7 +663,7 @@ export const SearchPage: FC<SearchPageProps> = ({
         </>
       )}
 
-      {!isLoading && results && activeCategory === 'Artists' && (
+      {results && activeCategory === 'Artists' && (
         <>
           {results.artists.length > 0 ? (
             <ShelfRow title="Artists">
@@ -740,6 +743,35 @@ export const SearchPage: FC<SearchPageProps> = ({
           )}
         </>
       )}
+
+      </div>
+      {isLoading && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+            background: results ? 'oklch(10% 0.005 270 / 0.35)' : 'transparent',
+          }}
+        >
+          <div
+            role="status"
+            aria-label="Searching"
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: '50%',
+              border: '3px solid var(--color-surface-3)',
+              borderTopColor: 'var(--color-accent)',
+              animation: 'vibeytm-spin 0.9s linear infinite',
+            }}
+          />
+        </div>
+      )}
+      </div>
 
     </section>
   );

--- a/src/components/player/NowPlaying.tsx
+++ b/src/components/player/NowPlaying.tsx
@@ -1,11 +1,21 @@
-import { type FC } from 'react';
+import { type FC, forwardRef, useEffect, useMemo, useRef } from 'react';
 import { usePlayerState } from '../../hooks/usePlayerState';
+import { useLyrics } from '../../hooks/useLyrics';
+import { useSmoothedPosition } from '../../hooks/useSmoothedPosition';
+import type { Lyrics, LyricLine } from '../../lib/types';
 import { CachedImage } from '../CachedImage';
 import { MarqueeText } from '../MarqueeText';
+
+/** Residual constant lag added on top of rAF interpolation. Covers the
+ *  fixed-ish pipeline delay (bridge poll read cycle + IPC + audio output
+ *  buffering). Tuned by ear against mainstream tracks with LRCLIB timings. */
+const LYRICS_CONSTANT_OFFSET_MS = 450;
 
 interface NowPlayingProps {
   isOpen: boolean;
   onClose: () => void;
+  /** When true, show lyrics in place of the cover centerpiece. */
+  showLyrics?: boolean;
 }
 
 /**
@@ -13,11 +23,34 @@ interface NowPlayingProps {
  * the sidebar and the player bar). Triggered by clicking the cover thumbnail
  * in the PlayerBar; toggling closes it.
  *
- * The cover image is the visual centerpiece, sized to a large square in the
- * middle of the page with the track title and artist beneath it.
+ * When `showLyrics` is true, the cover is swapped out for a lyrics panel.
+ * If YTM returned synced lyrics for the track, lines auto-highlight and
+ * auto-scroll with playback; otherwise the plain text is shown.
  */
-export const NowPlaying: FC<NowPlayingProps> = ({ isOpen, onClose }) => {
-  const { track } = usePlayerState();
+export const NowPlaying: FC<NowPlayingProps> = ({ isOpen, onClose, showLyrics = false }) => {
+  const { track, positionSecs, status } = usePlayerState();
+  const durationSecs = track?.durationSecs ?? 0;
+  // Auto-tuned position: the backend reports a fresh value every ~150 ms,
+  // but rAF interpolation fills the gap so lyric highlighting tracks the
+  // vocal at frame rate. A small constant offset on top covers residual
+  // audio-output buffering.
+  const smoothedPositionSecs = useSmoothedPosition(
+    positionSecs,
+    status === 'playing',
+    LYRICS_CONSTANT_OFFSET_MS,
+  );
+  const { status: lyricsStatus, lyrics, error: lyricsError } = useLyrics(
+    track
+      ? {
+          videoId: track.videoId,
+          artist: track.artist,
+          title: track.title,
+          durationSecs: track.durationSecs,
+        }
+      : null,
+    showLyrics && isOpen,
+    true, // user-initiated — skip the track-change debounce
+  );
 
   return (
     <div
@@ -40,14 +73,18 @@ export const NowPlaying: FC<NowPlayingProps> = ({ isOpen, onClose }) => {
         transition:
           'opacity 420ms cubic-bezier(0.22, 1, 0.36, 1), transform 420ms cubic-bezier(0.22, 1, 0.36, 1)',
         display: 'flex',
-        alignItems: 'center',
+        alignItems: 'flex-start',
         justifyContent: 'center',
-        padding: 'var(--space-6)',
+        // Match the sidebar nav's top padding (var(--space-3)) so the top of
+        // the cover / lyrics panel lines up with the Home button. Horizontal
+        // padding kept at space-6 to give content breathing room.
+        paddingTop: 'var(--space-3)',
+        paddingInline: 'var(--space-6)',
+        paddingBottom: 'var(--space-6)',
         overflow: 'hidden',
       }}
       aria-hidden={!isOpen}
     >
-      {/* Close (top-right corner) */}
       <button
         type="button"
         onClick={onClose}
@@ -84,99 +121,524 @@ export const NowPlaying: FC<NowPlayingProps> = ({ isOpen, onClose }) => {
           No track playing
         </p>
       ) : (
+        // Single layout in both modes — cover/title column on the left,
+        // lyrics column on the right. Toggling LRC animates the lyrics
+        // column's width and opacity (plus the left-margin gap) so the
+        // cover slides smoothly into place instead of remounting.
         <div
           style={{
             display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
+            flexDirection: 'row',
+            alignItems: 'flex-start',
             justifyContent: 'center',
-            gap: 'var(--space-5)',
-            // Fill the container so the cover can grow as large as the
-            // viewport allows.
-            width: '100%',
+            width: 'min(1200px, 100%)',
+            marginInline: 'auto',
             height: '100%',
           }}
         >
-          {/* Centered cover — largest square that fits the overlay, bounded
-              by viewport height (minus title bar, player bar, our own
-              padding, and ~160 px reserved for the title block) and viewport
-              width (minus sidebar and our padding). */}
           <div
             style={{
-              width:
-                'min(calc(100vh - var(--title-bar-height) - var(--player-bar-height) - var(--space-6) * 2 - 160px), calc(100vw - var(--sidebar-width) - var(--space-6) * 2))',
-              aspectRatio: '1',
-              borderRadius: 'var(--radius-lg)',
-              overflow: 'hidden',
-              background: 'var(--color-surface-2)',
-              boxShadow: '0 24px 60px oklch(0% 0 0 / 0.5)',
-              flexShrink: 0,
-            }}
-          >
-            <CachedImage
-              src={
-                track.artworkUrl ||
-                (track.videoId
-                  ? `https://i.ytimg.com/vi/${track.videoId}/hqdefault.jpg`
-                  : undefined)
-              }
-              alt={`${track.title} artwork`}
-              style={{
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-                display: 'block',
-              }}
-            />
-          </div>
-
-          {/* Title + artist */}
-          <div
-            style={{
-              width: 'min(calc(100vw - var(--sidebar-width) - var(--space-6) * 2), 720px)',
-              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 'var(--space-4)',
+              flex: '0 0 auto',
               minWidth: 0,
             }}
           >
-            <MarqueeText
-              text={track.title}
-              style={{
-                fontSize: 'var(--text-2xl)',
-                fontWeight: 700,
-                color: 'var(--color-text-primary)',
-                letterSpacing: '-0.02em',
-              }}
+            <Cover track={track} size="split" />
+            <TitleBlock
+              track={track}
+              width={coverSide}
+              align="center"
             />
-            <div
-              style={{
-                marginTop: 'var(--space-2)',
-                fontSize: 'var(--text-base)',
-                color: 'var(--color-text-secondary)',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {track.artist}
-            </div>
-            {track.album && (
-              <div
-                style={{
-                  marginTop: 'var(--space-1)',
-                  fontSize: 'var(--text-sm)',
-                  color: 'var(--color-text-tertiary)',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {track.album}
-              </div>
-            )}
           </div>
-
+          <div
+            aria-hidden={!showLyrics}
+            style={{
+              // Animated in/out. Width collapses to 0 when closed, gap
+              // lives here as marginLeft so it collapses with the column.
+              width: showLyrics ? `calc(${coverSide} / 2)` : '0',
+              marginLeft: showLyrics ? 'var(--space-5)' : '0',
+              opacity: showLyrics ? 1 : 0,
+              height: '100%',
+              minWidth: 0,
+              overflow: 'hidden',
+              pointerEvents: showLyrics ? 'auto' : 'none',
+              transition:
+                'width 420ms cubic-bezier(0.22, 1, 0.36, 1), margin-left 420ms cubic-bezier(0.22, 1, 0.36, 1), opacity 300ms cubic-bezier(0.22, 1, 0.36, 1)',
+            }}
+          >
+            <LyricsPanel
+              status={lyricsStatus}
+              lyrics={lyrics}
+              error={lyricsError}
+              positionSecs={smoothedPositionSecs}
+              durationSecs={durationSecs}
+              visible={showLyrics}
+            />
+          </div>
         </div>
       )}
     </div>
   );
 };
+
+interface TitleBlockProps {
+  track: { title: string; artist: string; album?: string };
+  /** CSS width (string) so the caller can constrain the marquee container. */
+  width: string;
+  align: 'center' | 'left';
+}
+
+const TitleBlock: FC<TitleBlockProps> = ({ track, width, align }) => (
+  <div style={{ width, textAlign: align, minWidth: 0 }}>
+    <MarqueeText
+      text={track.title}
+      style={{
+        fontSize: 'var(--text-2xl)',
+        fontWeight: 700,
+        color: 'var(--color-text-primary)',
+        letterSpacing: '-0.02em',
+      }}
+    />
+    <div
+      style={{
+        marginTop: 'var(--space-2)',
+        fontSize: 'var(--text-base)',
+        color: 'var(--color-text-secondary)',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+    >
+      {track.artist}
+    </div>
+    {track.album && (
+      <div
+        style={{
+          marginTop: 'var(--space-1)',
+          fontSize: 'var(--text-sm)',
+          color: 'var(--color-text-tertiary)',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {track.album}
+      </div>
+    )}
+  </div>
+);
+
+interface CoverProps {
+  track: { title: string; videoId?: string; artworkUrl?: string };
+  /** `full`: largest square that fits the viewport.
+   *  `split`: fixed medium size used alongside the lyrics panel. */
+  size: 'full' | 'split';
+}
+
+  // Single square side length used in BOTH cover-only and split modes so
+  // toggling the LRC button never resizes the cover. Constrained by:
+  //   • the 2/3 fraction of the 1200px-capped split row (horizontal cap),
+  //   • the same 2/3 of available viewport width on narrower windows,
+  //   • the viewport height minus chrome + title block so the cover fits.
+  const SPLIT_ROW_MAX = 1200;
+  const SPLIT_COVER_FRACTION = 2 / 3;
+  const coverSide = `min(${SPLIT_ROW_MAX * SPLIT_COVER_FRACTION}px, calc(${SPLIT_COVER_FRACTION} * (100vw - var(--sidebar-width) - var(--space-6) * 2)), calc(100vh - var(--title-bar-height) - var(--player-bar-height) - var(--space-3) - var(--space-6) - 160px))`;
+
+const Cover: FC<CoverProps> = ({ track, size }) => {
+  void size; // kept for API compatibility; both modes now share one size
+  const sideLength = coverSide;
+  return (
+    <div
+      style={{
+        width: sideLength,
+        aspectRatio: '1',
+        borderRadius: 'var(--radius-lg)',
+        overflow: 'hidden',
+        background: 'var(--color-surface-2)',
+        boxShadow: '0 24px 60px oklch(0% 0 0 / 0.5)',
+        flexShrink: 0,
+        // Smooth resize when the split mode toggles.
+        transition: 'width var(--duration-slow) var(--ease-out)',
+      }}
+    >
+      <CachedImage
+        src={
+          track.artworkUrl ||
+          (track.videoId ? `https://i.ytimg.com/vi/${track.videoId}/hqdefault.jpg` : undefined)
+        }
+        alt={`${track.title} artwork`}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          display: 'block',
+        }}
+      />
+    </div>
+  );
+};
+
+interface LyricsPanelProps {
+  status: 'idle' | 'loading' | 'available' | 'missing';
+  lyrics: Lyrics | null;
+  error: string | null;
+  positionSecs: number;
+  /** Track duration — used when no real per-line timings are available,
+   *  so we can still distribute lines and auto-scroll. */
+  durationSecs: number;
+  /** True when the parent column is expanded on screen. A false→true
+   *  transition triggers an instant snap to the currently-playing line. */
+  visible: boolean;
+}
+
+const CONTAINER_STYLE: React.CSSProperties = {
+  // flex:1 so the panel takes whatever horizontal space the split row has.
+  // Capped by max-width so it doesn't drift miles from the cover on very
+  // wide windows.
+  flex: 1,
+  maxWidth: '640px',
+  minWidth: 0,
+  // Fill the full content height of the overlay. The overlay itself already
+  // reserves the title-bar and player-bar on the outside via its top/bottom,
+  // and its own top/bottom padding (space-3 + space-6) — so the panel just
+  // stretches between those.
+  height:
+    'calc(100vh - var(--title-bar-height) - var(--player-bar-height) - var(--space-3) - var(--space-6))',
+  padding: 'var(--space-6)',
+  background: 'var(--color-surface-2)',
+  borderRadius: 'var(--radius-lg)',
+  boxShadow: '0 24px 60px oklch(0% 0 0 / 0.5)',
+  overflowY: 'auto',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-3)',
+};
+
+const LyricsPanel: FC<LyricsPanelProps> = ({
+  status,
+  lyrics,
+  error,
+  positionSecs,
+  durationSecs,
+  visible,
+}) => {
+  if (status === 'loading') {
+    return (
+      <div
+        style={{
+          ...CONTAINER_STYLE,
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        Loading lyrics…
+      </div>
+    );
+  }
+
+  const text = lyrics?.text.trim() ?? '';
+  const lines = lyrics?.lines ?? null;
+
+  if (status === 'missing' || (status === 'available' && !text && (!lines || lines.length === 0))) {
+    return (
+      <div
+        style={{
+          ...CONTAINER_STYLE,
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--color-text-tertiary)',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{ fontSize: 'var(--text-base)' }}>No lyrics for this track</p>
+        {error && (
+          <p style={{ fontSize: 'var(--text-xs)', marginTop: 'var(--space-2)' }}>{error}</p>
+        )}
+      </div>
+    );
+  }
+
+  // Prefer real per-line timings (YTM or LRCLIB). When they're absent we
+  // synthesize evenly-spaced timings so the panel still auto-scrolls and
+  // highlights — no "estimated" disclaimer shown.
+  const effectiveLines: LyricLine[] =
+    lines && lines.length > 0 ? lines : synthesizeLines(text, durationSecs);
+
+  return (
+    <TimedLyrics
+      lines={effectiveLines}
+      positionSecs={positionSecs}
+      source={lyrics?.source ?? null}
+      visible={visible}
+    />
+  );
+};
+
+/** Split plain text into lines and assign even timings across `durationSecs`.
+ *  Used when neither YTM nor LRCLIB returned per-line timings. */
+function synthesizeLines(text: string, durationSecs: number): LyricLine[] {
+  const raw = text.split(/\r?\n/);
+  const meaningful = raw.filter((t) => t.trim().length > 0);
+  if (meaningful.length === 0 || durationSecs <= 0) {
+    return raw.map((t) => ({
+      text: t,
+      startMs: Number.MAX_SAFE_INTEGER,
+      endMs: undefined,
+    }));
+  }
+  const perLineMs = (durationSecs * 1000) / meaningful.length;
+  let cursor = 0;
+  return raw.map((t) => {
+    if (t.trim().length === 0) {
+      return { text: t, startMs: cursor, endMs: cursor };
+    }
+    const start = cursor;
+    const end = cursor + perLineMs;
+    cursor = end;
+    return { text: t, startMs: start, endMs: end };
+  });
+}
+
+interface TimedLyricsProps {
+  lines: LyricLine[];
+  positionSecs: number;
+  source: string | null;
+  visible: boolean;
+}
+
+const TimedLyrics: FC<TimedLyricsProps> = ({ lines, positionSecs, source, visible }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const lineRefs = useRef<(HTMLDivElement | null)[]>([]);
+  // `true` once we've snapped to the current line at least once since the
+  // panel became visible. Reset when `visible` flips false or the line set
+  // changes so the NEXT time the panel opens we instant-jump to wherever
+  // playback is instead of scrolling up from line 0.
+  const hasLandedRef = useRef(false);
+
+  // `positionSecs` is already the rAF-smoothed + offset-adjusted clock from
+  // useSmoothedPosition, so we treat it as authoritative here.
+  const positionMs = Math.max(0, positionSecs * 1000);
+  const activeIndex = useMemo(() => findActiveLine(lines, positionMs), [lines, positionMs]);
+
+  // Auto-scroll: when the active line changes OR the panel becomes visible,
+  // bring the active line to the center of the scroll container. First
+  // scroll per visibility-session is instant ('auto'), subsequent ones
+  // animate ('smooth'). Skip entirely while hidden — scrolling a
+  // display-collapsed container has no effect and would burn cycles.
+  //
+  // Timing: the first scroll after visible→true waits for the column's
+  // 420 ms width animation to finish. During the animation, lines wrap at
+  // intermediate widths so each line's height is in flux — scrolling
+  // mid-anim lands on the wrong spot. Subsequent line advances scroll
+  // immediately since the layout is already stable.
+  useEffect(() => {
+    if (!visible) return;
+    if (activeIndex < 0) return;
+
+    const doScroll = () => {
+      const el = lineRefs.current[activeIndex];
+      const container = containerRef.current;
+      if (!el || !container) return;
+      const containerRect = container.getBoundingClientRect();
+      const elRect = el.getBoundingClientRect();
+      if (containerRect.height < 10) return;
+      const offset =
+        elRect.top - containerRect.top - containerRect.height / 2 + elRect.height / 2;
+      container.scrollBy({
+        top: offset,
+        behavior: hasLandedRef.current ? 'smooth' : 'auto',
+      });
+      hasLandedRef.current = true;
+    };
+
+    // Landed already? Just scroll for the line advance.
+    if (hasLandedRef.current) {
+      doScroll();
+      return;
+    }
+
+    // First scroll after opening: wait for the column width transition
+    // so measurements reflect the final layout.
+    const timer = setTimeout(doScroll, 450);
+    return () => clearTimeout(timer);
+  }, [visible, activeIndex]);
+
+  // Closing the panel OR switching tracks resets the "first landing" flag
+  // so the next open-or-play-next-song scroll is an instant snap.
+  useEffect(() => {
+    if (!visible) hasLandedRef.current = false;
+  }, [visible]);
+  useEffect(() => {
+    hasLandedRef.current = false;
+  }, [lines]);
+
+  return (
+    <div ref={containerRef} style={CONTAINER_STYLE}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+        {lines.map((line, i) => {
+          const isActive = i === activeIndex;
+          const isPast = i < activeIndex;
+          const progress = isActive ? computeLineProgress(line, lines[i + 1], positionMs) : 0;
+          return (
+            <LyricLineView
+              key={i}
+              ref={(el) => {
+                lineRefs.current[i] = el;
+              }}
+              text={line.text}
+              isActive={isActive}
+              isPast={isPast}
+              progress={progress}
+            />
+          );
+        })}
+      </div>
+      {source && (
+        <div
+          style={{
+            marginTop: 'var(--space-3)',
+            fontSize: 'var(--text-xs)',
+            color: 'var(--color-text-tertiary)',
+            borderTop: '1px solid oklch(100% 0 0 / 0.06)',
+            paddingTop: 'var(--space-2)',
+          }}
+        >
+          {source}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function findActiveLine(lines: LyricLine[], positionMs: number): number {
+  if (lines.length === 0 || positionMs < lines[0].startMs) {
+    return -1;
+  }
+  let lo = 0;
+  let hi = lines.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (lines[mid].startMs <= positionMs) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
+}
+
+/** Progress through the current line in [0, 1]. Uses the line's own end or
+ *  the next line's start when the line has no explicit end timestamp. */
+function computeLineProgress(
+  line: LyricLine,
+  next: LyricLine | undefined,
+  positionMs: number,
+): number {
+  const endMs = line.endMs ?? next?.startMs;
+  if (endMs === undefined || endMs <= line.startMs) {
+    return 0;
+  }
+  const raw = (positionMs - line.startMs) / (endMs - line.startMs);
+  if (raw <= 0) return 0;
+  if (raw >= 1) return 1;
+  return raw;
+}
+
+interface LyricLineViewProps {
+  text: string;
+  isActive: boolean;
+  isPast: boolean;
+  /** 0..1 — progress through the line, only read when isActive is true. */
+  progress: number;
+}
+
+/**
+ * Renders one lyric line with a left-to-right karaoke wipe. Two stacked
+ * copies: a dim base (always visible) and a bright overlay clipped to the
+ * current progress so as playback advances, bright pixels grow out of the
+ * left edge.
+ */
+const LyricLineView = forwardRef<HTMLDivElement, LyricLineViewProps>(
+  ({ text, isActive, isPast, progress }, ref) => {
+    // When active, the line's text color matches the song title
+    // (var(--color-text-primary)) so the highlighted line reads at full
+    // contrast against the panel background. The wipe overlay stays in the
+    // same color family; progress shows via a subtle brightness jump from
+    // dim-to-full opacity as each syllable is sung.
+    const baseColor = isActive
+      ? 'var(--color-text-primary)'
+      : isPast
+        ? 'var(--color-text-tertiary)'
+        : 'var(--color-text-secondary)';
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          position: 'relative',
+          paddingInline: '0',
+          paddingBlock: isActive ? 'var(--space-2)' : 'var(--space-1)',
+          fontSize: isActive ? 'var(--text-xl)' : 'var(--text-base)',
+          fontWeight: isActive ? 800 : 500,
+          lineHeight: 1.4,
+          letterSpacing: isActive ? '-0.01em' : '0',
+          // Inactive lines fade hard so the active title-colored line
+          // dominates the panel.
+          opacity: isActive ? 1 : isPast ? 0.35 : 0.55,
+          transition:
+            'font-size var(--duration-normal) var(--ease-out), font-weight var(--duration-normal) var(--ease-out), opacity var(--duration-normal) var(--ease-out), letter-spacing var(--duration-normal) var(--ease-out), border-color var(--duration-normal) var(--ease-out), padding var(--duration-normal) var(--ease-out), color var(--duration-normal) var(--ease-out)',
+          userSelect: 'text',
+          color: baseColor,
+        }}
+      >
+        {/* Base layer — the real, selectable text. Dimmed by default. */}
+        <span style={{ transition: 'color var(--duration-normal) var(--ease-out)' }}>
+          {text || ' '}
+        </span>
+
+        {/* Wipe overlay — only meaningful while this line is active. Stays
+            mounted so the clip-path transition doesn't flicker on each
+            activeIndex change.
+            Positioned to match the BASE text's content-box edge (inset
+            matches the parent's paddingBlock) so the overlay's text lines
+            up pixel-for-pixel with the base — no overlap. Font properties
+            (weight, size, letter-spacing, line-height, color) match the
+            active base too, so the two layers wrap identically. */}
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: isActive ? 'var(--space-2)' : 'var(--space-1)',
+            bottom: isActive ? 'var(--space-2)' : 'var(--space-1)',
+            left: 0,
+            right: 0,
+            color: 'var(--color-text-primary)',
+            fontWeight: 800,
+            fontSize: 'inherit',
+            lineHeight: 'inherit',
+            letterSpacing: 'inherit',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            pointerEvents: 'none',
+            opacity: isActive ? 1 : 0,
+            // clip-path inset(top right bottom left) — shrink the right edge
+            // inward as progress recedes so the visible overlay grows from
+            // left to right as the vocal advances.
+            clipPath: isActive
+              ? `inset(0 ${(1 - progress) * 100}% 0 0)`
+              : 'inset(0 100% 0 0)',
+            transition:
+              'clip-path 250ms linear, opacity var(--duration-normal) var(--ease-out), top var(--duration-normal) var(--ease-out), bottom var(--duration-normal) var(--ease-out)',
+          }}
+        >
+          {text || ' '}
+        </span>
+      </div>
+    );
+  },
+);
+LyricLineView.displayName = 'LyricLineView';

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import { browseApi } from '../lib/ipc';
+import type { Lyrics } from '../lib/types';
+
+// Shared caches — a Map for hits and a Map for confirmed misses so the UI
+// can instantly render both states without re-hitting YTM. A pending
+// Promise map de-duplicates concurrent fetches from PlayerBar + NowPlaying.
+//
+// Transient errors (webview mid-navigation, timeouts, bridge glitches) are
+// NOT cached — otherwise a track change that happens to race the probe
+// would permanently disable the lyrics button for that video.
+const lyricsCache = new Map<string, Lyrics>();
+const lyricsMisses = new Map<string, string | null>();
+const inFlight = new Map<string, Promise<void>>();
+
+// Probes that fire the instant a track-change event arrives often collide
+// with YTM's own webview navigation ("JS fetch error: Load failed"). A
+// short delay lets the WKWebView settle before we ask it to run a fetch.
+const PROBE_DEBOUNCE_MS = 2000;
+
+export type LyricsStatus = 'idle' | 'loading' | 'available' | 'missing';
+
+export interface UseLyricsResult {
+  status: LyricsStatus;
+  lyrics: Lyrics | null;
+  error: string | null;
+}
+
+export interface LyricsLookup {
+  videoId: string;
+  artist?: string | null;
+  title?: string | null;
+  durationSecs?: number | null;
+}
+
+function hasContent(l: Lyrics): boolean {
+  const text = l.text?.trim() ?? '';
+  const lines = l.lines ?? null;
+  return text.length > 0 || (Array.isArray(lines) && lines.length > 0);
+}
+
+/**
+ * Kick off a background lyrics fetch for a track the user is likely to
+ * play soon (e.g. next in the queue). Fire-and-forget: result lands in
+ * the shared cache, so when the user actually plays the track and opens
+ * the LRC panel, it's already available. Safe to call with any frequency
+ * — repeat calls for the same videoId are no-ops thanks to the cache +
+ * in-flight maps.
+ */
+export function preloadLyrics(lookup: LyricsLookup): void {
+  if (!lookup.videoId) return;
+  void ensureFetch(lookup);
+}
+
+async function fetchOnce(lookup: LyricsLookup) {
+  return browseApi.getLyrics({
+    videoId: lookup.videoId,
+    artist: lookup.artist ?? null,
+    title: lookup.title ?? null,
+    durationSecs: lookup.durationSecs ?? null,
+  });
+}
+
+function ensureFetch(lookup: LyricsLookup): Promise<void> {
+  const { videoId } = lookup;
+  if (lyricsCache.has(videoId) || lyricsMisses.has(videoId)) {
+    return Promise.resolve();
+  }
+  const existing = inFlight.get(videoId);
+  if (existing) return existing;
+
+  // Try immediately, then once more after ~1.5 s if the first attempt
+  // throws. That covers the most common failure mode: an eager probe
+  // firing while YTM's webview is still navigating to the new track.
+  // Eventual "YTM says no lyrics" results STILL cache a miss; only
+  // transport/JS-bridge errors retry.
+  const runOnce = async (): Promise<'ok' | 'empty' | 'error'> => {
+    try {
+      const result = await fetchOnce(lookup);
+      if (hasContent(result)) {
+        lyricsCache.set(videoId, result);
+        return 'ok';
+      }
+      return 'empty';
+    } catch {
+      return 'error';
+    }
+  };
+
+  const p = (async () => {
+    const first = await runOnce();
+    if (first === 'ok') return;
+    if (first === 'empty') {
+      lyricsMisses.set(videoId, null);
+      return;
+    }
+    // Transient error: wait and retry once.
+    await new Promise((r) => setTimeout(r, 1500));
+    const second = await runOnce();
+    if (second === 'empty') {
+      lyricsMisses.set(videoId, null);
+    }
+    // On second error, leave the track un-cached so a future call retries.
+  })().finally(() => {
+    inFlight.delete(videoId);
+  });
+
+  inFlight.set(videoId, p);
+  return p;
+}
+
+/**
+ * Subscribe to lyrics availability for a given track. Safe to call from
+ * multiple components — the underlying fetch is de-duplicated and cached.
+ *
+ * `enabled = false` holds off the fetch entirely (used by NowPlaying when
+ * the panel is closed). `immediate = true` skips the debounce — NowPlaying
+ * uses this because the user has just clicked to open the panel and wants
+ * lyrics right now.
+ */
+export function useLyrics(
+  lookup: LyricsLookup | null,
+  enabled = true,
+  immediate = false,
+): UseLyricsResult {
+  const [, force] = useState(0);
+
+  const videoId = lookup?.videoId;
+  // Pick up lookup metadata in deps so a later-arriving artist/title (common
+  // on cold bridge load) re-triggers the probe with richer params.
+  const artist = lookup?.artist ?? null;
+  const title = lookup?.title ?? null;
+  const duration = lookup?.durationSecs ?? null;
+
+  useEffect(() => {
+    if (!enabled || !videoId) return;
+    if (lyricsCache.has(videoId) || lyricsMisses.has(videoId)) return;
+
+    let cancelled = false;
+
+    const run = () => {
+      if (cancelled) return;
+      ensureFetch({ videoId, artist, title, durationSecs: duration }).then(() => {
+        if (!cancelled) force((v) => v + 1);
+      });
+    };
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    if (immediate || inFlight.has(videoId)) {
+      run();
+    } else {
+      timer = setTimeout(run, PROBE_DEBOUNCE_MS);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [videoId, enabled, immediate, artist, title, duration]);
+
+  if (!videoId) {
+    return { status: 'idle', lyrics: null, error: null };
+  }
+  const hit = lyricsCache.get(videoId);
+  if (hit) {
+    return { status: 'available', lyrics: hit, error: null };
+  }
+  if (lyricsMisses.has(videoId)) {
+    return { status: 'missing', lyrics: null, error: lyricsMisses.get(videoId) ?? null };
+  }
+  return { status: 'loading', lyrics: null, error: null };
+}

--- a/src/hooks/useSmoothedPosition.ts
+++ b/src/hooks/useSmoothedPosition.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Interpolate playback position between backend POSITION_UPDATED events
+ * using `requestAnimationFrame`, so lyric highlighting advances smoothly
+ * at ~60 fps instead of stepping every ~150 ms when a new backend sample
+ * arrives.
+ *
+ * How it auto-tunes: every time `positionSecs` lands, we reset the
+ * baseline to (that value, wall-clock now). While playing, rAF ticks
+ * update the returned value to `baseline.pos + (now - baseline.at)`. Since
+ * we re-base on every backend update, small clock skew can't drift.
+ *
+ * `constantOffsetMs` is an optional fixed forward-shift that compensates
+ * for residual pipeline lag (poll cycle + audio output buffering). It
+ * defaults to 0 — the rAF interpolation alone often gets within a vocal
+ * syllable.
+ */
+export function useSmoothedPosition(
+  positionSecs: number,
+  isPlaying: boolean,
+  constantOffsetMs = 0,
+): number {
+  const [value, setValue] = useState(positionSecs + constantOffsetMs / 1000);
+
+  useEffect(() => {
+    // Snapshot the backend reading and the instant we saw it. Everything
+    // else in this effect derives from these two numbers, so rAF ticks
+    // can't drift relative to real time.
+    const baselinePos = positionSecs;
+    const baselineAt = performance.now();
+
+    if (!isPlaying) {
+      setValue(baselinePos + constantOffsetMs / 1000);
+      return;
+    }
+
+    let raf = 0;
+    const tick = () => {
+      const elapsedSecs = (performance.now() - baselineAt) / 1000;
+      setValue(baselinePos + elapsedSecs + constantOffsetMs / 1000);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [positionSecs, isPlaying, constantOffsetMs]);
+
+  return value;
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke, convertFileSrc } from '@tauri-apps/api/core';
-import type { AccountInfo, PlayerState, TrackInfo, SearchResults, Shelf, PlaylistSummary, PlaylistDetail, AlbumSummary, ArtistSummary } from './types';
+import type { AccountInfo, PlayerState, TrackInfo, SearchResults, Shelf, PlaylistSummary, PlaylistDetail, AlbumSummary, ArtistSummary, Lyrics } from './types';
 import type { RepeatMode } from './types';
 
 export interface CacheStats {
@@ -79,6 +79,20 @@ export const browseApi = {
     invoke<void>('save_playlist_to_library', { playlistId }),
   removePlaylistFromLibrary: (playlistId: string) =>
     invoke<void>('remove_playlist_from_library', { playlistId }),
+  getLyrics: (params: {
+    videoId: string;
+    artist?: string | null;
+    title?: string | null;
+    durationSecs?: number | null;
+  }) =>
+    invoke<Lyrics>('get_lyrics', {
+      videoId: params.videoId,
+      artist: params.artist ?? null,
+      title: params.title ?? null,
+      durationSecs: params.durationSecs ?? null,
+    }),
+  getUpcomingTracks: (videoId: string, limit = 3) =>
+    invoke<TrackInfo[]>('get_upcoming_tracks', { videoId, limit }),
 };
 
 export async function playFirstFromPlaylist(playlistId: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,3 +90,16 @@ export interface Shelf {
   title: string;
   items: ShelfContent;
 }
+
+export interface LyricLine {
+  startMs: number;
+  endMs?: number | null;
+  text: string;
+}
+
+export interface Lyrics {
+  text: string;
+  source?: string | null;
+  /** Per-line timings when YTM returned synced lyrics; else null. */
+  lines?: LyricLine[] | null;
+}


### PR DESCRIPTION
## Summary

- **Timed lyrics pipeline** with three-tier fallback: YTM's own synced lines (`elementRenderer → timedLyricsModel`) → parallel LRCLIB + NetEase race via `tokio::select!` → plain text with synthetic timings. External fallbacks only run when YTM confirms lyrics exist, so instrumentals don't get the vocal original's lyrics.
- **Persistent disk cache** at `{app_data}/cache/lyrics/{videoId}.json` (7d + jitter TTL) plus shared in-memory cache / in-flight de-dupe in `useLyrics`. Single retry after 1.5s on transient errors.
- **Upcoming-queue preload**: new `get_upcoming_tracks(video_id, limit)` command parses YTM's `playlistPanelRenderer.contents` (handles both the direct `playlistPanelVideoRenderer` form and the newer `playlistPanelVideoWrapperRenderer.primaryRenderer` wrap). PlayerBar fires `preloadLyrics` on the first two upcoming tracks so skipping forward usually hits cache.
- **YTM request context upgrade**: `webview_bridge::api::ytm_api_call` reads `ytcfg.INNERTUBE_CONTEXT` and `INNERTUBE_API_KEY` from inside the YTM page, adds `X-YouTube-Client-Name: 67` / `X-YouTube-Client-Version` headers, and appends `&key=` to the URL — unlocking Elements-rendered responses the minimal hand-crafted context missed.
- **Karaoke playing page**: single-row layout for both cover-only and lyrics-open modes. Cover 2/3, lyrics 1/3 of a 1200px-capped row. Per-line left-to-right `clip-path` wipe synced to playback; container auto-scrolls to keep active line centered (instant first scroll, smooth subsequent). Panel top-aligns with sidebar Home button. Cover stays the same size whether the lyrics panel is open or closed; column animates in/out over 420ms with no tree remount.
- **LRC button**: always clickable. Dim opacity signals "no lyrics" without disabling the click.
- **Blur-and-spinner reload**: new `<LoadingSpinner>` + `<ReloadOverlay>` primitives. Home, Explore, Library, PlaylistDetail, and Search now keep previously-rendered content visible (10px blur + centered spinner) while refetching instead of wiping to "Loading…".

## Test plan

- [x] `pnpm typecheck` clean
- [x] `cargo check` clean
- [x] `cargo test --lib` — 57 passed, 0 failed
- [ ] Manual: play a track with YTM synced lyrics → karaoke wipe + auto-scroll
- [ ] Manual: play a Chinese track (LRCLIB slow / NetEase fast path)
- [ ] Manual: play instrumental piano track → LRC button dims, panel shows "No lyrics"
- [ ] Manual: open LRC mid-track → lyrics snap to current line
- [ ] Manual: click Next → lyrics for next track already cached (verify via `grep get_upcoming_tracks /tmp/vibeytm-dev.log`)
- [ ] Manual: click Refresh on Home page → content blurs + spinner instead of wiping to "Loading…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)