### PR TITLE
Podcasts polish + UI symmetry: show covers, search tab, sticky frosted heroes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/cache/mod.rs
+++ b/src-tauri/src/cache/mod.rs
@@ -213,7 +213,22 @@ impl Cache {
             }
         }
 
-        let bytes = reqwest::get(url)
+        // YouTube's CDN — particularly the
+        // `lh3.googleusercontent.com/youtube-podcasts-ingestion-proxy/…`
+        // URLs used for show covers — rejects requests with an empty
+        // User-Agent (`bad status`). Use a standard Safari UA so all
+        // image hosts (album art, channel art, podcast covers) accept
+        // the fetch.
+        const SAFARI_UA: &str =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_0) AppleWebKit/605.1.15 \
+             (KHTML, like Gecko) Version/16.6 Safari/605.1.15";
+        let client = reqwest::Client::builder()
+            .user_agent(SAFARI_UA)
+            .build()
+            .context("building image fetch client")?;
+        let bytes = client
+            .get(url)
+            .send()
             .await
             .with_context(|| format!("fetching {url}"))?
             .error_for_status()

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -1201,6 +1201,7 @@ const FILTER_ARTISTS: &str = "EgWKAQIgAWoSEA4QCRAKEAUQBBADEBUQEBAR";
 #[allow(dead_code)]
 const FILTER_VIDEOS: &str = "EgWKAQIQAWoSEA4QCRAKEAUQBBADEBUQEBAR";
 const FILTER_PLAYLISTS: &str = "EgWKAQIoAWoSEA4QCRAKEAUQBBADEBUQEBAR";
+const FILTER_PODCASTS: &str = "EgWKAQJQAWoSEA4QCRAKEAUQBBADEBUQEBAR";
 
 /// Extract autocomplete suggestion strings from a `music/get_search_suggestions`
 /// response. The response wraps each suggestion in a `searchSuggestionRenderer`
@@ -1234,6 +1235,7 @@ fn parse_search_results(data: &Value, filter: Option<&str>) -> SearchResults {
     let mut albums = Vec::new();
     let mut artists = Vec::new();
     let mut playlists = Vec::new();
+    let mut podcasts: Vec<PodcastSummary> = Vec::new();
     let mut top_album: Option<AlbumSummary> = None;
 
     let tabs = &data["contents"]["tabbedSearchResultsRenderer"]["tabs"];
@@ -1242,7 +1244,14 @@ fn parse_search_results(data: &Value, filter: Option<&str>) -> SearchResults {
         .and_then(|t| t["tabRenderer"]["content"]["sectionListRenderer"]["contents"].as_array());
 
     let Some(sections) = sections else {
-        return SearchResults { songs, albums, artists, playlists, top_album };
+        return SearchResults {
+            songs,
+            albums,
+            artists,
+            playlists,
+            podcasts,
+            top_album,
+        };
     };
 
     for section in sections {
@@ -1300,6 +1309,11 @@ fn parse_search_results(data: &Value, filter: Option<&str>) -> SearchResults {
                                 playlists.push(pl);
                             }
                         }
+                        Some(FILTER_PODCASTS) => {
+                            if let Some(p) = parse_podcast_from_list_item(renderer) {
+                                podcasts.push(p);
+                            }
+                        }
                         _ => {
                             // Songs, Videos, or no filter — parse as tracks
                             if let Some(track) = parse_track_from_list_item(renderer) {
@@ -1312,7 +1326,14 @@ fn parse_search_results(data: &Value, filter: Option<&str>) -> SearchResults {
         }
     }
 
-    SearchResults { songs, albums, artists, playlists, top_album }
+    SearchResults {
+        songs,
+        albums,
+        artists,
+        playlists,
+        podcasts,
+        top_album,
+    }
 }
 
 fn extract_continuation(data: &Value) -> Option<String> {
@@ -2165,6 +2186,53 @@ fn parse_playlist_detail(data: &Value, playlist_id: &str) -> PlaylistDetail {
                 })
         });
 
+    // Artist credit from the responsive header. Albums ship the artist
+    // in `straplineTextOne.runs` (a dedicated artist line under the
+    // album title) — NOT in `subtitle.runs`, which is just
+    // `Album • 2026`. Skipped for shows / podcasts since their
+    // strapline carries the channel name and we don't want to
+    // mis-credit a channel as an artist.
+    let is_show_browse = playlist_id.starts_with("MPSP");
+    let artist: Option<String> = if is_show_browse {
+        None
+    } else {
+        // Primary path: musicResponsiveHeaderRenderer.straplineTextOne.runs
+        responsive_header
+            .and_then(|h| h["straplineTextOne"]["runs"].as_array())
+            .and_then(|arr| {
+                let joined = arr
+                    .iter()
+                    .filter_map(|r| r["text"].as_str())
+                    .collect::<String>();
+                let trimmed = joined.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            })
+            // Legacy fallbacks: musicDetailHeaderRenderer.subtitle.runs
+            // (older responses) — pattern is `Album • Artist • 2023`.
+            // Pick a run that has a browseEndpoint (the artist link).
+            .or_else(|| {
+                let detail_subtitle = data["header"]["musicDetailHeaderRenderer"]["subtitle"]
+                    ["runs"]
+                    .as_array()
+                    .or_else(|| {
+                        editable_inner["musicDetailHeaderRenderer"]["subtitle"]["runs"].as_array()
+                    })?;
+                detail_subtitle.iter().find_map(|r| {
+                    let text = r["text"].as_str()?.trim();
+                    if text.is_empty() {
+                        return None;
+                    }
+                    r["navigationEndpoint"]["browseEndpoint"]["browseId"]
+                        .as_str()
+                        .map(|_| text.to_string())
+                })
+            })
+    };
+
     // For shows / podcasts, override every episode's per-row artwork
     // with the show's own cover. YTM stamps each episode card with a
     // different thumbnail (a graphic from inside the episode), but
@@ -2190,6 +2258,7 @@ fn parse_playlist_detail(data: &Value, playlist_id: &str) -> PlaylistDetail {
         audio_playlist_id,
         is_album,
         year,
+        artist,
     }
 }
 

--- a/src-tauri/src/ytm_api/types.rs
+++ b/src-tauri/src/ytm_api/types.rs
@@ -9,6 +9,11 @@ pub struct SearchResults {
     pub albums: Vec<AlbumSummary>,
     pub artists: Vec<ArtistSummary>,
     pub playlists: Vec<PlaylistSummary>,
+    /// Podcast / show shelves from the search response. Populated only when
+    /// the caller passes the podcasts filter param; absent in the unified
+    /// (no-filter) search view since the user picks the surface explicitly.
+    #[serde(default)]
+    pub podcasts: Vec<PodcastSummary>,
     /// First real album surfaced from an unfiltered search response. Used by
     /// the unified search view to render the "Top result" album hero. None
     /// when no album was found or when the search was filtered.
@@ -108,6 +113,13 @@ pub struct PlaylistDetail {
     /// playlists, charts, mood mixes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub year: Option<String>,
+    /// Artist / creator from the responsive-header subtitle. For albums
+    /// this is the credited artist (frequently absent from per-track
+    /// rows since the album header already carries it). Skipped for
+    /// shows / podcasts and for playlists where the subtitle has no
+    /// artist run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artist: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { ShortcutCheatsheet } from './components/ShortcutCheatsheet';
 import { useBootState } from './hooks/useBootState';
 import { useGlobalShortcuts, type ShortcutBinding } from './hooks/useGlobalShortcuts';
 import { ytmApi, playerApi } from './lib/ipc';
-import { registerOpenArtist } from './lib/appNav';
+import { registerOpenArtist, registerOpenPlaylist } from './lib/appNav';
 
 interface ViewingPlaylist {
   id: string;
@@ -122,6 +122,22 @@ const App: FC = () => {
     registerOpenArtist(searchForArtist);
     return () => registerOpenArtist(null);
   }, [searchForArtist]);
+
+  // Same registry pattern for "open playlist / show". Used by the Now
+  // Playing overlay's artist-line click to jump to a podcast show's
+  // MPSP detail page. Closes every overlay first so the playlist page
+  // is the focus once it opens.
+  useEffect(() => {
+    const handler = (playlistId: string): void => {
+      setIsNowPlayingOpen(false);
+      setIsLyricsOpen(false);
+      setIsQueueOpen(false);
+      setViewingArtist(null);
+      openPlaylistDetail(playlistId);
+    };
+    registerOpenPlaylist(handler);
+    return () => registerOpenPlaylist(null);
+  }, [openPlaylistDetail]);
 
   // Global keyboard shortcuts. Active only in the app phase (no point
   // intercepting Cmd+L while the LoginPage is up). Bindings stay as a

--- a/src/components/DetailPageHero.tsx
+++ b/src/components/DetailPageHero.tsx
@@ -33,6 +33,10 @@ interface DetailPageHeroProps {
    * hasn't completed yet.
    */
   colors: CoverColors;
+  /** Artist / creator subtitle rendered between title and meta. Bigger
+   *  and more prominent than the meta line — Apple-Music style. Skipped
+   *  when omitted (e.g. ArtistPage where the title IS the artist). */
+  artist?: string;
   /** "12 songs · 42 min" or similar. Optional — artist pages skip it. */
   meta?: string;
   /** Free-form text rendered below the meta line in tertiary color. */
@@ -49,6 +53,13 @@ interface DetailPageHeroProps {
   save?: DetailPageHeroSaveProps;
   /** Optional extra nodes rendered after the action row. */
   extra?: ReactNode;
+  /**
+   * When true, render with a transparent background instead of the
+   * cover-tinted radial gradient. Used by sticky-hero parents that
+   * want their own backdrop-filter blur to show scrolled content
+   * through the hero (see ArtistPage).
+   */
+  transparent?: boolean;
 }
 
 /**
@@ -71,6 +82,7 @@ export const DetailPageHero: FC<DetailPageHeroProps> = ({
   kind,
   coverUrl,
   colors,
+  artist,
   meta,
   description,
   onBack,
@@ -78,6 +90,7 @@ export const DetailPageHero: FC<DetailPageHeroProps> = ({
   onShuffle,
   save,
   extra,
+  transparent = false,
 }) => {
   // Memoize the gradient so re-renders driven by frequent player events
   // (track-change, position update) don't recompute the string. Same
@@ -101,7 +114,7 @@ export const DetailPageHero: FC<DetailPageHeroProps> = ({
         // the cover/title block so the track list sits directly below
         // the hero with no extra gap.
         padding: 'calc(var(--title-bar-height) + var(--space-3)) var(--space-6) var(--space-3)',
-        background: backdrop,
+        background: transparent ? 'transparent' : backdrop,
         // Smooth color transition when colors prop updates after async
         // palette extraction settles.
         transition: 'background 700ms var(--ease-out)',
@@ -213,6 +226,20 @@ export const DetailPageHero: FC<DetailPageHeroProps> = ({
           >
             {title}
           </h1>
+          {artist && (
+            <div
+              style={{
+                fontSize: 'var(--text-base)',
+                fontWeight: 600,
+                color: 'var(--color-accent)',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {artist}
+            </div>
+          )}
           {meta && (
             <div
               style={{

--- a/src/components/layout/PlayerChrome.tsx
+++ b/src/components/layout/PlayerChrome.tsx
@@ -69,6 +69,9 @@ interface ChromeButtonProps {
   children: ReactNode;
   isActive?: boolean;
   size?: number;
+  /** Render greyed-out and ignore clicks. Used by the lyrics button
+   *  when a podcast is playing — there are no lyrics to look up. */
+  disabled?: boolean;
 }
 
 /**
@@ -87,39 +90,47 @@ const ChromeButton: FC<ChromeButtonProps> = ({
   children,
   isActive = false,
   size = 28,
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-label={label}
-    aria-pressed={isActive}
-    style={{
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      width: `${size}px`,
-      height: `${size}px`,
-      padding: 0,
-      background: 'transparent',
-      border: 'none',
-      cursor: 'pointer',
-      color: isActive
-        ? 'var(--color-accent)'
-        : 'var(--color-text-primary)',
-      opacity: isActive ? 1 : 0.92,
-      transition:
-        'color var(--duration-fast) var(--ease-out), opacity var(--duration-fast) var(--ease-out)',
-    }}
-    onMouseEnter={(e) => {
-      e.currentTarget.style.opacity = '1';
-    }}
-    onMouseLeave={(e) => {
-      e.currentTarget.style.opacity = isActive ? '1' : '0.92';
-    }}
-  >
-    {children}
-  </button>
-);
+  disabled = false,
+}) => {
+  const restingOpacity = disabled ? 0.35 : isActive ? 1 : 0.92;
+  return (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      aria-label={label}
+      aria-pressed={isActive}
+      aria-disabled={disabled}
+      disabled={disabled}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: `${size}px`,
+        height: `${size}px`,
+        padding: 0,
+        background: 'transparent',
+        border: 'none',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        color: isActive
+          ? 'var(--color-accent)'
+          : 'var(--color-text-primary)',
+        opacity: restingOpacity,
+        transition:
+          'color var(--duration-fast) var(--ease-out), opacity var(--duration-fast) var(--ease-out)',
+      }}
+      onMouseEnter={(e) => {
+        if (disabled) return;
+        e.currentTarget.style.opacity = '1';
+      }}
+      onMouseLeave={(e) => {
+        if (disabled) return;
+        e.currentTarget.style.opacity = isActive ? '1' : '0.92';
+      }}
+    >
+      {children}
+    </button>
+  );
+};
 
 export const PlayerChrome: FC<PlayerChromeProps> = ({
   onToggleNowPlaying,
@@ -130,8 +141,13 @@ export const PlayerChrome: FC<PlayerChromeProps> = ({
   queueOpen,
 }) => {
   const state = usePlayerState();
-  const { track, status, volume, isShuffled, repeatMode, applyOptimistic } = state;
+  const { track, status, volume, isShuffled, repeatMode, applyOptimistic, activePlaylistId } = state;
   const isPlaying = status === 'playing';
+  // YTM podcasts/shows ride the same player surface as music, but have
+  // no lyrics to look up — the LRC fetch (LRCLIB / NetEase) is built
+  // around song title + artist, not episode metadata. Detect via the
+  // active playlist context: MPSP* browseIds are show / podcast feeds.
+  const isPodcastContext = (activePlaylistId ?? '').startsWith('MPSP');
 
   // Background preload of the CURRENT track's lyrics + the next track's
   // lyrics + cover. Routed through `useDeferredEffect` so the bridge
@@ -302,8 +318,15 @@ export const PlayerChrome: FC<PlayerChromeProps> = ({
       style={{
         position: 'fixed',
         bottom: 'var(--space-3)',
-        left: 'calc(var(--sidebar-width) + var(--space-4))',
-        right: 'var(--space-4)',
+        // Both gutters use `--space-6` (24 px) — same as the page
+        // section's horizontal padding above. Equal visible gap on
+        // both sides of the chrome capsule, window-size-independent.
+        // Bumped from `--space-4` (16 px) so the right gap visually
+        // matches the left despite the window's rounded bottom-right
+        // corner curving inward (the bottom-left is hidden behind
+        // the sidebar so no curve is visible there).
+        left: 'calc(var(--sidebar-width) + var(--space-6))',
+        right: 'var(--space-6)',
         // Explicit height — `<LiquidGlass>` inside takes 100 % of its
         // parent. Without this the footer auto-fits and the WebGL/SVG
         // wrapper collapses, clipping the controls' top edge.
@@ -487,9 +510,16 @@ export const PlayerChrome: FC<PlayerChromeProps> = ({
 
         {track && (
           <ChromeButton
-            label={lyricsOpen ? 'Hide lyrics' : 'Show lyrics'}
+            label={
+              isPodcastContext
+                ? 'Lyrics unavailable for podcasts'
+                : lyricsOpen
+                  ? 'Hide lyrics'
+                  : 'Show lyrics'
+            }
             onClick={onToggleLyrics}
-            isActive={lyricsOpen}
+            isActive={lyricsOpen && !isPodcastContext}
+            disabled={isPodcastContext}
             size={28}
           >
             <LyricsIcon size={20} />

--- a/src/components/layout/PlayerChrome.tsx
+++ b/src/components/layout/PlayerChrome.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, useEffect, useRef } from 'react';
+import { type FC, type ReactNode, useEffect, useRef, useState } from 'react';
 import { LiquidGlass } from '@liquidglass/react';
 import { usePlayerState } from '../../hooks/usePlayerState';
 import { preloadLyrics } from '../../hooks/useLyrics';
@@ -296,6 +296,12 @@ export const PlayerChrome: FC<PlayerChromeProps> = ({
   // between mute and the user's previous level. Default to 0.5 if the
   // user opened the app already at 0 (so unmute does something visible).
   const lastNonZeroVolumeRef = useRef<number>(volume > 0 ? volume : 0.5);
+  // Volume slider visibility — Apple-Music-style hover reveal. The
+  // slider sits next to the speaker button; both share a wrapper that
+  // toggles `isVolumeHovered` on enter/leave. Width animates from 0
+  // (collapsed) → 55px (expanded) so the slot doesn't visually
+  // jitter the surrounding chrome on toggle.
+  const [isVolumeHovered, setIsVolumeHovered] = useState(false);
   useEffect(() => {
     if (volume > 0) lastNonZeroVolumeRef.current = volume;
   }, [volume]);
@@ -449,6 +455,16 @@ export const PlayerChrome: FC<PlayerChromeProps> = ({
         }}
       >
         <div
+          // Apple-Music-style volume control: speaker button always
+          // visible, slider hidden by default and revealed on hover
+          // over either the button or the slider's reserved slot. Both
+          // share a wrapper so the slider stays open while the user
+          // moves between button and slider thumb. Width animates so
+          // the chrome doesn't jitter during the reveal.
+          onMouseEnter={() => setIsVolumeHovered(true)}
+          onMouseLeave={() => setIsVolumeHovered(false)}
+          onFocus={() => setIsVolumeHovered(true)}
+          onBlur={() => setIsVolumeHovered(false)}
           style={{
             display: 'flex',
             alignItems: 'center',
@@ -499,8 +515,14 @@ export const PlayerChrome: FC<PlayerChromeProps> = ({
               );
             }}
             aria-label="Volume"
+            tabIndex={isVolumeHovered ? 0 : -1}
             style={{
-              width: '55px', /* 2/3 of prior 83px */
+              width: isVolumeHovered ? '55px' : '0px',
+              opacity: isVolumeHovered ? 1 : 0,
+              pointerEvents: isVolumeHovered ? 'auto' : 'none',
+              overflow: 'hidden',
+              transition:
+                'width var(--duration-normal) var(--ease-out), opacity var(--duration-normal) var(--ease-out)',
               backgroundImage: `linear-gradient(to right, var(--color-text-secondary) ${
                 volume * 100
               }%, var(--color-surface-3) ${volume * 100}%)`,

--- a/src/components/pages/ArtistPage.tsx
+++ b/src/components/pages/ArtistPage.tsx
@@ -167,8 +167,15 @@ export const ArtistPage: FC<ArtistPageProps> = ({
             >
               Top songs
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
-              {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                columnGap: 'var(--space-4)',
+                rowGap: 'var(--space-1)',
+              }}
+            >
+              {Array.from({ length: 6 }).map((_, i) => (
                 <SkeletonRow key={i} />
               ))}
             </div>
@@ -233,7 +240,14 @@ export const ArtistPage: FC<ArtistPageProps> = ({
           >
             Top songs
           </h2>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+              columnGap: 'var(--space-4)',
+              rowGap: 'var(--space-1)',
+            }}
+          >
             {songs.map((track, idx) => (
               <SongRow
                 key={`${track.videoId || 'track'}-${idx}`}

--- a/src/components/pages/ArtistPage.tsx
+++ b/src/components/pages/ArtistPage.tsx
@@ -8,7 +8,6 @@ import { SongRow } from '../browse/SongRow';
 import { AlbumCard } from '../browse/AlbumCard';
 import { LoadingSpinner } from '../LoadingOverlay';
 import { DetailPageHero } from '../DetailPageHero';
-import { LiquidGlass } from '@liquidglass/react';
 import { SkeletonRow, SkeletonCard } from '../Skeleton';
 
 interface ArtistPageProps {
@@ -117,66 +116,36 @@ export const ArtistPage: FC<ArtistPageProps> = ({
         overflow: 'auto',
       }}
     >
-      {/* Sticky LiquidGlass title plate — same shape as HomePage. */}
-      <div style={{ height: 'var(--space-3)', flexShrink: 0 }} aria-hidden="true" />
+      {/* Sticky hero — the cover/title block stays pinned at the top
+          of the page while the songs/albums content scrolls underneath.
+          Transparent background + backdrop-filter blur so scrolled
+          rows show through with a frosted-glass effect. */}
       <div
         style={{
           position: 'sticky',
-          top: 'var(--space-3)',
+          top: 0,
           zIndex: 10,
-          margin: '0 var(--space-6) var(--space-4)',
+          flexShrink: 0,
+          background: 'transparent',
+          backdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
+          WebkitBackdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
         }}
       >
-        <LiquidGlass
-          borderRadius={150}
-          blur={8}
-          contrast={1.2}
-          brightness={1.05}
-          saturation={1.1}
-          shadowIntensity={0.25}
-          displacementScale={1}
-          elasticity={1}
-          zIndex={10}
-        >
-          <div
-            style={{
-              width: '100%',
-              padding:
-                'calc(var(--title-bar-height) - var(--space-3)) var(--space-10) var(--space-3)',
-              background: 'oklch(20% 0.005 270 / 0.30)',
-              borderRadius: 'inherit',
-            }}
-          >
-            <h1
-              style={{
-                fontSize: 'var(--text-2xl)',
-                fontWeight: 700,
-                letterSpacing: '-0.02em',
-                color: 'var(--color-text-primary)',
-                margin: 0,
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {artistName}
-            </h1>
-          </div>
-        </LiquidGlass>
+        <DetailPageHero
+          title={artistName}
+          kind="Artist"
+          coverUrl={heroCover ?? ''}
+          colors={heroColors}
+          meta={
+            songs.length > 0 || albums.length > 0
+              ? `${songs.length} songs · ${albums.length} albums`
+              : undefined
+          }
+          onBack={onBack}
+          onPlay={handlePlayAll}
+          transparent
+        />
       </div>
-      <DetailPageHero
-        title={artistName}
-        kind="Artist"
-        coverUrl={heroCover ?? ''}
-        colors={heroColors}
-        meta={
-          songs.length > 0 || albums.length > 0
-            ? `${songs.length} songs · ${albums.length} albums`
-            : undefined
-        }
-        onBack={onBack}
-        onPlay={handlePlayAll}
-      />
 
       <div
         style={{
@@ -313,12 +282,29 @@ export const ArtistPage: FC<ArtistPageProps> = ({
 };
 
 /**
- * Loose case-insensitive substring match between a track/album's artist
- * field and the page's artist name. Covers "Fleetwood Mac" matching
- * "Fleetwood Mac & Stevie Nicks" while filtering out unrelated results
- * that the YTM search blends in (covers, similar artists, etc.).
+ * Loose case-insensitive match between a track/album's artist field and
+ * the page's artist name. Tolerant of two real-world quirks:
+ *
+ *   - YTM library artist names often combine native + romanized forms
+ *     ("周杰倫 - Jay Chou"), but per-song artist fields only carry one
+ *     ("周杰倫"). Plain `field.includes(target)` returned false because
+ *     the target was *longer* than the field.
+ *   - Multi-artist credits ("Fleetwood Mac & Stevie Nicks") should still
+ *     match a "Fleetwood Mac" page.
+ *
+ * Strategy: split the target on common separators and accept the row
+ * when ANY non-trivial token of the target is contained in the field
+ * — and also keep the original substring check so collaborator pages
+ * keep working.
  */
 function matchesArtist(field: string, target: string): boolean {
   if (!field || !target) return false;
-  return field.toLowerCase().includes(target.toLowerCase());
+  const f = field.toLowerCase();
+  const t = target.toLowerCase();
+  if (f.includes(t) || t.includes(f)) return true;
+  const tokens = t
+    .split(/\s*[-–—&,/、|]\s*|\s+(?:feat\.?|featuring|with|x|vs\.?)\s+/i)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= 2);
+  return tokens.some((tok) => f.includes(tok));
 }

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -2,6 +2,8 @@ import { type FC, useEffect, useState } from 'react';
 import type { PlaylistDetail } from '../../lib/types';
 import { browseApi, playerApi } from '../../lib/ipc';
 import { rememberTrackArtworks } from '../../lib/trackArtworkRegistry';
+import { rememberShowCover } from '../../lib/showCoverRegistry';
+import { rememberTrackMetas } from '../../lib/trackMetaRegistry';
 import { useCoverColors } from '../../hooks/useCoverColors';
 import { albumArtOrNothing } from '../../lib/artwork';
 import { SongRow } from '../browse/SongRow';
@@ -96,6 +98,19 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
         // surface them. Same flow for albums (MPRE browseIds also
         // route through getPlaylist).
         rememberTrackArtworks(data.tracks);
+        // Show / podcast cover side-channel — keyed by MPSP browseId so
+        // the now-playing Cover can pick up the show's channel art for
+        // any episode of this show, regardless of what host YTM serves
+        // it from. The strict per-track artwork registry above drops
+        // covers on hosts outside `lh*|yt3.googleusercontent.com`.
+        rememberShowCover(playlistId, data.artworkUrl);
+        // Per-track title + artist side-channel — recovers podcast
+        // queue rows whose `.song-title` / `.byline` DOM scrape comes
+        // back empty because YTM uses a different element shape for
+        // episode list items. The Rust parser (`parse_episode_from_
+        // multi_row`) populates these correctly, so caching them here
+        // gives `<QueueRow>` a reliable fallback.
+        rememberTrackMetas(data.tracks);
         setPlaylist(data);
         // Seed the saved-state from the server so the button renders the
         // correct label on first paint (issue #55). Without this the button
@@ -308,7 +323,12 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
   // Both are pure-frontend computations from the existing tracks
   // payload — no Rust parser change needed.
   const primaryArtist = (() => {
-    if (isShow || playlist.tracks.length === 0) return undefined;
+    if (isShow) return undefined;
+    // Header-credited artist wins — albums often omit the per-track
+    // artist field since the header carries it. Falls back to the
+    // distinct set of per-track artists for playlists / mixes.
+    if (playlist.artist) return playlist.artist;
+    if (playlist.tracks.length === 0) return undefined;
     const distinct = new Set<string>();
     for (const t of playlist.tracks) {
       if (t.artist) distinct.add(t.artist);
@@ -329,8 +349,10 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
     if (hours > 0) return `${hours} hr ${minutes} min`;
     return `${minutes} min`;
   };
+  // Artist is hoisted into its own subtitle line (DetailPageHero
+  // `artist` prop) so it reads with prominence instead of vanishing
+  // into the small gray meta string.
   const metaParts: string[] = [];
-  if (primaryArtist) metaParts.push(primaryArtist);
   if (playlist.year) metaParts.push(playlist.year);
   if (playlist.trackCount !== undefined) {
     metaParts.push(`${playlist.trackCount} ${isShow ? 'episodes' : 'songs'}`);
@@ -341,24 +363,34 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
   return (
     <section
       style={{
-        // Cover the entire right column of the AppShell grid — top to
-        // bottom, edge to edge of the right side. The hero (cover, title,
-        // play-all, save) is pinned to the top of the page; only the
-        // track list inside the lower flex child scrolls.
         display: 'flex',
         flexDirection: 'column',
-        height: '100vh',
-        overflow: 'hidden',
+        height: '100%',
+        overflow: 'auto',
       }}
     >
-      {/* Fixed hero block — flexShrink: 0 keeps it at its natural
-          height while the sibling track list owns the scroll. */}
-      <div style={{ flexShrink: 0 }}>
+      {/* Sticky hero — same chrome as ArtistPage. Cover/title/meta/
+          actions stay pinned at the top of the page while the track
+          list scrolls underneath. Transparent background +
+          backdrop-filter blur so scrolled rows show through with a
+          frosted-glass effect. */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 10,
+          flexShrink: 0,
+          background: 'transparent',
+          backdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
+          WebkitBackdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
+        }}
+      >
         <DetailPageHero
           title={playlist.title}
           kind={isShow ? 'Show' : isAlbum ? 'Album' : 'Playlist'}
           coverUrl={playlist.artworkUrl ?? ''}
           colors={heroColors}
+          artist={primaryArtist}
           meta={heroMeta}
           description={playlist.description ?? undefined}
           onBack={onBack}
@@ -371,23 +403,20 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
             onToggle: toggleSaved,
             error: saveError,
           }}
+          transparent
         />
       </div>
 
-      {/* Track list — only scrolling region on the page. The wrapper
-          shares the hero's left margin (space-6) so the row's outer
-          edge — and the hover/selection background that paints to
-          that edge — aligns with the hero cover image's left. The
-          row's own internal padding stays inside that edge as
-          breathing room for the row's content. */}
+      {/* Track list. The wrapper shares the hero's left margin
+          (space-6) so the row's outer edge — and the hover/selection
+          background that paints to that edge — aligns with the hero
+          cover image's left. The row's own internal padding stays
+          inside that edge as breathing room for the row's content. */}
       <div
         style={{
-          flex: 1,
-          minHeight: 0,
-          overflowY: 'auto',
           display: 'flex',
           flexDirection: 'column',
-          padding: '0 var(--space-6) 0 var(--space-6)',
+          padding: '0 var(--space-6)',
         }}
       >
         {playlist.tracks.map((track, i) => (
@@ -410,22 +439,18 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
             No tracks found
           </div>
         )}
-        {/* Invisible spacer so the last song row clears the floating
-            player chrome. Height = player-bar-height (chrome itself) +
-            space-3 (chrome's bottom margin from the window) + space-3
-            (breathing room above the chrome). WebKit's
-            `overflow: auto` excludes paddingBottom from `scrollHeight`,
-            so the spacer must be a real DOM child to extend the
-            scrollable area. */}
-        <div
-          aria-hidden="true"
-          style={{
-            flexShrink: 0,
-            height:
-              'calc(var(--player-bar-height) + var(--space-3) * 2)',
-          }}
-        />
       </div>
+      {/* Invisible spacer so the last song row clears the floating
+          player chrome. WebKit's `overflow: auto` excludes
+          paddingBottom from `scrollHeight`, so the spacer must be a
+          real DOM child to extend the scrollable area. */}
+      <div
+        aria-hidden="true"
+        style={{
+          flexShrink: 0,
+          height: 'calc(var(--player-bar-height) + var(--space-3) * 2)',
+        }}
+      />
     </section>
   );
 };

--- a/src/components/pages/SearchPage/index.tsx
+++ b/src/components/pages/SearchPage/index.tsx
@@ -22,7 +22,7 @@ const MIN_SUGGEST_LENGTH = 3;
 const MAX_SUGGESTIONS = 5;
 const PREVIEW_TRACK_COUNT = 3;
 
-const CATEGORY_TABS = ['Songs', 'Albums', 'Artists', 'Playlists'] as const;
+const CATEGORY_TABS = ['Songs', 'Albums', 'Artists', 'Playlists', 'Podcasts'] as const;
 type CategoryTab = (typeof CATEGORY_TABS)[number];
 
 const CATEGORY_PARAMS: Record<CategoryTab, string | undefined> = {
@@ -30,6 +30,7 @@ const CATEGORY_PARAMS: Record<CategoryTab, string | undefined> = {
   Albums: 'EgWKAQIYAWoSEA4QCRAKEAUQBBADEBUQEBAR',
   Artists: 'EgWKAQIgAWoSEA4QCRAKEAUQBBADEBUQEBAR',
   Playlists: 'EgWKAQIoAWoSEA4QCRAKEAUQBBADEBUQEBAR',
+  Podcasts: 'EgWKAQJQAWoSEA4QCRAKEAUQBBADEBUQEBAR',
 };
 
 interface SearchPageProps {
@@ -780,6 +781,34 @@ export const SearchPage: FC<SearchPageProps> = ({
             </ShelfRow>
           ) : (
             <EmptyCategory label="playlists" />
+          )}
+        </>
+      )}
+
+      {results && activeCategory === 'Podcasts' && (
+        <>
+          {results.podcasts && results.podcasts.length > 0 ? (
+            <ShelfRow title="Podcasts">
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+                  gap: '20px',
+                }}
+              >
+                {results.podcasts.map((show) => (
+                  <AlbumCard
+                    key={show.browseId}
+                    artworkUrl={show.artworkUrl}
+                    title={show.title}
+                    subtitle={show.author}
+                    onClick={() => onOpenPlaylist?.(show.browseId)}
+                  />
+                ))}
+              </div>
+            </ShelfRow>
+          ) : (
+            <EmptyCategory label="podcasts" />
           )}
         </>
       )}

--- a/src/components/pages/SearchPage/index.tsx
+++ b/src/components/pages/SearchPage/index.tsx
@@ -15,6 +15,7 @@ import {
 import { TopAlbumCover } from './TopAlbumCover';
 import { EmptyCategory } from './EmptyCategory';
 import { LiquidGlass } from '@liquidglass/react';
+import { openArtist } from '../../../lib/appNav';
 
 const SUGGEST_DEBOUNCE_MS = 200;
 const MIN_QUERY_LENGTH = 2;
@@ -680,7 +681,14 @@ export const SearchPage: FC<SearchPageProps> = ({
 
           {results.songs.length > 0 && (
             <ShelfRow title="Songs">
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                  columnGap: 'var(--space-4)',
+                  rowGap: 'var(--space-1)',
+                }}
+              >
                 {results.songs.map((track, i) => (
                   <SongRow key={track.videoId || `song-${i}`} track={track} />
                 ))}
@@ -699,7 +707,14 @@ export const SearchPage: FC<SearchPageProps> = ({
         <>
           {results.songs.length > 0 ? (
             <ShelfRow title="Songs">
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                  columnGap: 'var(--space-4)',
+                  rowGap: 'var(--space-1)',
+                }}
+              >
                 {results.songs.map((track, i) => (
                   <SongRow key={track.videoId || `song-${i}`} track={track} />
                 ))}
@@ -830,12 +845,11 @@ export const SearchPage: FC<SearchPageProps> = ({
                   <button
                     key={artist.channelId}
                     onClick={() => {
-                      // Switch back to the unified view, then submit a fresh
-                      // search for this artist's name. submitQuery sets both
-                      // `query` and `submittedQuery`, which fires the search
-                      // effect with the new (artist, null) cache key.
-                      setActiveCategory(null);
-                      submitQuery(artist.name);
+                      // Open the dedicated ArtistPage instead of just
+                      // re-running the search. `openArtist` flows
+                      // through App's `searchForArtist` registry handler,
+                      // which closes overlays and sets viewingArtist.
+                      openArtist(artist.name);
                     }}
                     style={{
                       display: 'flex',

--- a/src/components/player/NowPlaying/index.tsx
+++ b/src/components/player/NowPlaying/index.tsx
@@ -4,6 +4,9 @@ import { usePlayerState } from '../../../hooks/usePlayerState';
 import { useAudioCounterpartArtwork } from '../../../hooks/useAudioCounterpartArtwork';
 import { useCoverColors } from '../../../hooks/useCoverColors';
 import { albumArtOrNothing } from '../../../lib/artwork';
+import { lookupTrackArtwork } from '../../../lib/trackArtworkRegistry';
+import { lookupShowCover } from '../../../lib/showCoverRegistry';
+import { openArtist, openPlaylist } from '../../../lib/appNav';
 import { ArtworkPlaceholder } from '../../ArtworkPlaceholder';
 import { CachedImage } from '../../CachedImage';
 import { MarqueeText } from '../../MarqueeText';
@@ -46,7 +49,7 @@ export const NowPlaying: FC<NowPlayingProps> = ({ isOpen, showLyrics = false, qu
   // itself is now an independent overlay (LyricsOverlay) — NowPlaying just
   // owns the cover positioning so the cover slides left to make room.
   const splitMode = showLyrics || queueOpen;
-  const { track } = usePlayerState();
+  const { track, activePlaylistId } = usePlayerState();
 
   return (
     <SafeOverlay
@@ -72,6 +75,7 @@ export const NowPlaying: FC<NowPlayingProps> = ({ isOpen, showLyrics = false, qu
         splitMode={splitMode}
         track={track}
         coverSide={coverSide}
+        activePlaylistId={activePlaylistId ?? null}
       />
     </SafeOverlay>
   );
@@ -84,12 +88,14 @@ interface NowPlayingBodyProps {
   splitMode: boolean;
   track: ReturnType<typeof usePlayerState>['track'];
   coverSide: string;
+  activePlaylistId: string | null;
 }
 
 const NowPlayingBody: FC<NowPlayingBodyProps> = ({
   splitMode,
   track,
   coverSide,
+  activePlaylistId,
 }) => {
   const backdropUrl = albumArtOrNothing(track?.artworkUrl);
   const coverColors = useCoverColors(backdropUrl ?? undefined);
@@ -140,11 +146,16 @@ const NowPlayingBody: FC<NowPlayingBodyProps> = ({
             minWidth: 0,
           }}
         >
-          <Cover track={track} size="split" />
+          <Cover
+            track={track}
+            size="split"
+            activePlaylistId={activePlaylistId}
+          />
           <TitleBlock
             track={track}
             width={coverSide}
             align="center"
+            activePlaylistId={activePlaylistId}
           />
         </div>
       )}
@@ -157,53 +168,107 @@ interface TitleBlockProps {
   /** CSS width (string) so the caller can constrain the marquee container. */
   width: string;
   align: 'center' | 'left';
+  /** Active source-playlist context for the currently playing track. When
+   *  it starts with `MPSP`, the artist line links to the show's MPSP page
+   *  instead of triggering an artist search. */
+  activePlaylistId: string | null;
 }
 
-const TitleBlock: FC<TitleBlockProps> = ({ track, width, align }) => (
-  <div style={{ width, textAlign: align, minWidth: 0 }}>
-    <MarqueeText
-      text={track.title}
-      style={{
-        fontSize: 'var(--text-2xl)',
-        fontWeight: 700,
-        color: 'var(--color-text-primary)',
-        letterSpacing: '-0.02em',
-      }}
-    />
-    <div
-      style={{
-        marginTop: 'var(--space-2)',
-        fontSize: 'var(--text-base)',
-        color: 'var(--color-text-secondary)',
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-      }}
-    >
-      {track.artist}
-    </div>
-    {track.album && (
-      <div
+const TitleBlock: FC<TitleBlockProps> = ({
+  track,
+  width,
+  align,
+  activePlaylistId,
+}) => {
+  // Podcast / show episodes: artist field carries the show name (see
+  // parse_episode_from_multi_row), and `activePlaylistId` is the show's
+  // MPSP* browseId. Click should jump to the show page rather than to
+  // an artist-search of the show's name.
+  const isPodcastEpisode = (activePlaylistId ?? '').startsWith('MPSP');
+  const handleArtistClick = (): void => {
+    if (isPodcastEpisode && activePlaylistId) {
+      openPlaylist(activePlaylistId);
+      return;
+    }
+    if (track.artist) {
+      openArtist(track.artist);
+    }
+  };
+  const canNavigate = isPodcastEpisode
+    ? !!activePlaylistId
+    : !!track.artist;
+  return (
+    <div style={{ width, textAlign: align, minWidth: 0 }}>
+      <MarqueeText
+        text={track.title}
         style={{
-          marginTop: 'var(--space-1)',
-          fontSize: 'var(--text-sm)',
-          color: 'var(--color-text-tertiary)',
+          fontSize: 'var(--text-2xl)',
+          fontWeight: 700,
+          color: 'var(--color-text-primary)',
+          letterSpacing: '-0.02em',
+        }}
+      />
+      <button
+        type="button"
+        onClick={canNavigate ? handleArtistClick : undefined}
+        disabled={!canNavigate}
+        aria-label={
+          isPodcastEpisode
+            ? `Open show ${track.artist}`
+            : `Open artist ${track.artist}`
+        }
+        style={{
+          display: 'block',
+          width: '100%',
+          marginTop: 'var(--space-2)',
+          padding: 0,
+          background: 'none',
+          border: 'none',
+          fontSize: 'var(--text-base)',
+          color: 'var(--color-text-secondary)',
+          textAlign: align,
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
+          cursor: canNavigate ? 'pointer' : 'default',
+        }}
+        onMouseEnter={(e) => {
+          if (canNavigate) e.currentTarget.style.color = 'var(--color-text-primary)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.color = 'var(--color-text-secondary)';
         }}
       >
-        {track.album}
-      </div>
-    )}
-  </div>
-);
+        {track.artist}
+      </button>
+      {track.album && (
+        <div
+          style={{
+            marginTop: 'var(--space-1)',
+            fontSize: 'var(--text-sm)',
+            color: 'var(--color-text-tertiary)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {track.album}
+        </div>
+      )}
+    </div>
+  );
+};
 
 interface CoverProps {
   track: { title: string; videoId?: string; artworkUrl?: string };
   /** `full`: largest square that fits the viewport.
    *  `split`: fixed medium size used alongside the lyrics panel. */
   size: 'full' | 'split';
+  /** Active source-playlist context. When it starts with `MPSP*`, the
+   *  cover falls back to the show's channel art (looked up by browseId
+   *  in the show-cover registry) since podcast episodes don't surface
+   *  album art through the audio-counterpart hook. */
+  activePlaylistId: string | null;
 }
 
   // Single square side length used in BOTH cover-only and split modes so
@@ -215,13 +280,17 @@ interface CoverProps {
   const SPLIT_COVER_FRACTION = 2 / 3;
   const coverSide = `min(${SPLIT_ROW_MAX * SPLIT_COVER_FRACTION}px, calc(${SPLIT_COVER_FRACTION} * (100vw - var(--sidebar-width) - var(--space-6) * 2)), calc(100vh - var(--title-bar-height) - var(--player-bar-height) - var(--space-3) - 160px))`;
 
-const Cover: FC<CoverProps> = ({ track, size }) => {
+const Cover: FC<CoverProps> = ({ track, size, activePlaylistId }) => {
   void size; // kept for API compatibility; both modes now share one size
   const sideLength = coverSide;
   const counterpartArtwork = useAudioCounterpartArtwork(
     track.videoId,
     track.artworkUrl,
   );
+  const isPodcastContext = (activePlaylistId ?? '').startsWith('MPSP');
+  const showCoverUrl = isPodcastContext
+    ? lookupShowCover(activePlaylistId)
+    : undefined;
   return (
     <div
       style={{
@@ -257,13 +326,25 @@ const Cover: FC<CoverProps> = ({ track, size }) => {
           }}
         >
           {(() => {
-            // NEVER show a video thumbnail here. Use the audio counterpart's
-            // album cover when the hook has resolved one; otherwise the
-            // bridge's captured artworkUrl IF AND ONLY IF it's actually
-            // album art; otherwise a placeholder. Issue #48's "letterbox
-            // the music video" workaround is no longer needed because the
-            // music-video frame is gone from this surface entirely.
-            const url = albumArtOrNothing(counterpartArtwork ?? track.artworkUrl);
+            // For podcast / show episodes, prefer the show's channel
+            // art. Pulled from the show-cover registry (populated by
+            // PlaylistDetailPage when the user visits any MPSP
+            // playlist), keyed by the active MPSP browseId rather
+            // than per-episode videoId. Bypasses the album-art host
+            // filter because the channel page renders the same URL
+            // via `<CachedImage>` with no host check, so we can trust
+            // it here too. NEVER falls back to a video thumbnail.
+            // Source order:
+            //   1. Show-cover registry (if podcast context)
+            //   2. Audio counterpart's album cover (from /next)
+            //   3. Bridge's captured artworkUrl
+            //   4. Per-track artwork registry
+            // Falls through to placeholder only when none resolve.
+            const url =
+              showCoverUrl ??
+              albumArtOrNothing(counterpartArtwork) ??
+              albumArtOrNothing(track.artworkUrl) ??
+              albumArtOrNothing(lookupTrackArtwork(track.videoId));
             if (!url) return <ArtworkPlaceholder size={500} />;
             return (
               <CachedImage

--- a/src/components/player/NowPlayingCard.tsx
+++ b/src/components/player/NowPlayingCard.tsx
@@ -3,6 +3,7 @@ import { usePlayerState } from '../../hooks/usePlayerState';
 import { useAudioCounterpartArtwork } from '../../hooks/useAudioCounterpartArtwork';
 import { useSmoothedPosition } from '../../hooks/useSmoothedPosition';
 import { albumArtOrNothing } from '../../lib/artwork';
+import { lookupShowCover } from '../../lib/showCoverRegistry';
 import { ArtworkPlaceholder } from '../ArtworkPlaceholder';
 import { CachedImage } from '../CachedImage';
 import { MarqueeText } from '../MarqueeText';
@@ -28,13 +29,29 @@ const formatTime = (secs: number): string => {
  * toggle was removed in this redesign).
  */
 export const NowPlayingCard: FC<Props> = ({ onOpenNowPlaying, nowPlayingOpen }) => {
-  const { track, status, positionSecs, isLiked, applyOptimistic, markSeek } =
-    usePlayerState();
+  const {
+    track,
+    status,
+    positionSecs,
+    isLiked,
+    applyOptimistic,
+    markSeek,
+    activePlaylistId,
+  } = usePlayerState();
   const isPlaying = status === 'playing';
   const counterpartArtwork = useAudioCounterpartArtwork(
     track?.videoId,
     track?.artworkUrl,
   );
+  // Same fallback as NowPlaying overlay: when a podcast / show is the
+  // active source, prefer the show's channel art (registered by
+  // PlaylistDetailPage when the user opened the show). The bridge
+  // emits an `i.ytimg.com/vi/...` video thumbnail for episodes which
+  // `albumArtOrNothing` rejects, leaving the card with a placeholder.
+  const isPodcastContext = (activePlaylistId ?? '').startsWith('MPSP');
+  const showCoverUrl = isPodcastContext
+    ? lookupShowCover(activePlaylistId)
+    : undefined;
 
   const handleToggleLike = () => {
     applyOptimistic({ isLiked: !isLiked });
@@ -57,7 +74,9 @@ export const NowPlayingCard: FC<Props> = ({ onOpenNowPlaying, nowPlayingOpen }) 
     duration > 0 ? Math.min(1, Math.max(0, safePosition / duration)) : 0;
   const remaining = Math.max(0, duration - safePosition);
 
-  const artUrl = albumArtOrNothing(counterpartArtwork ?? track?.artworkUrl ?? null);
+  const artUrl =
+    showCoverUrl ??
+    albumArtOrNothing(counterpartArtwork ?? track?.artworkUrl ?? null);
 
   return (
     <div

--- a/src/components/player/QueuePanel/QueueArtwork.tsx
+++ b/src/components/player/QueuePanel/QueueArtwork.tsx
@@ -2,6 +2,8 @@ import { type FC, useEffect, useState } from 'react';
 import { ArtworkPlaceholder } from '../../ArtworkPlaceholder';
 import { CachedImage } from '../../CachedImage';
 import type { TrackInfo } from '../../../lib/types';
+import { usePlayerState } from '../../../hooks/usePlayerState';
+import { lookupShowCover } from '../../../lib/showCoverRegistry';
 import { artworkChain } from './artwork';
 
 interface QueueArtworkProps {
@@ -34,11 +36,24 @@ export const QueueArtwork: FC<QueueArtworkProps> = ({ track, liveTrack }) => {
   // row's own track if not provided or mismatched.
   const sourceTrack =
     liveTrack && liveTrack.videoId === track.videoId ? liveTrack : track;
-  const chain = artworkChain(sourceTrack);
+  // Show / podcast context: every queue row is an episode of the same
+  // show, so the show's channel cover (registered by
+  // `PlaylistDetailPage`) is the right thumbnail for every row. Prepend
+  // it to the chain so it wins over the (typically empty for podcasts)
+  // strict album-art chain. Bypasses the album-art-only host filter
+  // because the channel page renders the same URL via `<CachedImage>`
+  // with no host check, so we trust it here too.
+  const { activePlaylistId } = usePlayerState();
+  const isPodcastContext = (activePlaylistId ?? '').startsWith('MPSP');
+  const showCoverUrl = isPodcastContext
+    ? lookupShowCover(activePlaylistId)
+    : undefined;
+  const baseChain = artworkChain(sourceTrack);
+  const chain = showCoverUrl ? [showCoverUrl, ...baseChain] : baseChain;
   const [chainIdx, setChainIdx] = useState(0);
   useEffect(() => {
     setChainIdx(0);
-  }, [sourceTrack.videoId, sourceTrack.artworkUrl]);
+  }, [sourceTrack.videoId, sourceTrack.artworkUrl, showCoverUrl]);
   const src = chain[chainIdx];
   if (!src) return <ArtworkPlaceholder size={40} />;
   return (

--- a/src/components/player/QueuePanel/QueueRow.tsx
+++ b/src/components/player/QueuePanel/QueueRow.tsx
@@ -3,6 +3,7 @@ import type { TrackInfo } from '../../../lib/types';
 import { QueueArtwork } from './QueueArtwork';
 import { ContextMenuTarget } from '../../contextMenu/ContextMenu';
 import { buildTrackContextMenu } from '../../contextMenu/trackActions';
+import { lookupTrackMeta } from '../../../lib/trackMetaRegistry';
 
 /**
  * Three vertical bars that bounce in sequence — the universal "audio is
@@ -68,6 +69,18 @@ export const QueueRow: FC<QueueRowProps> = ({
 }) => {
   const interactive = Boolean(onPlay) && !highlighted;
 
+  // Bridge JS scrapes podcast / show episode rows via selectors
+  // (`.song-title`, `.byline`) that don't match the multi-row episode
+  // shape, so episode queue rows arrive with empty title + artist. Fall
+  // back to the per-track metadata registry that
+  // `PlaylistDetailPage` populates from the Rust parser, which has
+  // proper episode title + show-name artist.
+  const meta = (!track.title || !track.artist)
+    ? lookupTrackMeta(track.videoId)
+    : undefined;
+  const displayTitle = track.title || meta?.title || 'Unknown title';
+  const displayArtist = track.artist || meta?.artist || '';
+
   const content = (
     <>
       <div
@@ -97,7 +110,7 @@ export const QueueRow: FC<QueueRowProps> = ({
             textOverflow: 'ellipsis',
           }}
         >
-          {track.title || 'Unknown title'}
+          {displayTitle}
         </div>
         <div
           style={{
@@ -108,7 +121,7 @@ export const QueueRow: FC<QueueRowProps> = ({
             textOverflow: 'ellipsis',
           }}
         >
-          {track.artist || ''}
+          {displayArtist}
         </div>
       </div>
     </>

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -140,6 +140,35 @@ export function usePlayerState(): UsePlayerState {
     });
   });
 
+  // Re-pull `activePlaylistId` from Rust whenever the videoId actually
+  // changes (NOT on metadata-refinement re-emits — the poller fires
+  // TRACK_CHANGED multiple times per real track swap as the title /
+  // duration / artwork land). Rust's `play_track` writes the new
+  // context (e.g. `MPSP…` for a podcast episode) but doesn't emit a
+  // dedicated state-change event, so without this the frontend's copy
+  // is whatever the initial getState() returned — and surfaces gated
+  // on it (e.g. the lyrics button's podcast disable in PlayerChrome)
+  // wouldn't flip when the user switched between songs and episodes.
+  const trackVideoId = state.track?.videoId;
+  useEffect(() => {
+    if (!trackVideoId) return;
+    let cancelled = false;
+    playerApi
+      .getState()
+      .then((s) => {
+        if (cancelled) return;
+        setState((prev) =>
+          prev.activePlaylistId === s.activePlaylistId
+            ? prev
+            : { ...prev, activePlaylistId: s.activePlaylistId },
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [trackVideoId]);
+
   useTauriEvent<PlaybackStatus>(EVENTS.STATUS_CHANGED, (status) => {
     // Suppress stale "paused" echoes right after a seek: YTM briefly
     // reports paused while the video element reseats the buffer, and the

--- a/src/lib/appNav.ts
+++ b/src/lib/appNav.ts
@@ -11,8 +11,10 @@
  */
 
 type ArtistNavHandler = (artistName: string) => void;
+type PlaylistNavHandler = (playlistId: string) => void;
 
 let openArtistHandler: ArtistNavHandler | null = null;
+let openPlaylistHandler: PlaylistNavHandler | null = null;
 
 export function registerOpenArtist(handler: ArtistNavHandler | null): void {
   openArtistHandler = handler;
@@ -24,4 +26,18 @@ export function openArtist(artistName: string): void {
 
 export function hasOpenArtistHandler(): boolean {
   return openArtistHandler !== null;
+}
+
+/**
+ * Mirror of `registerOpenArtist` for opening a playlist / album / show by
+ * its YTM browseId or playlistId. Used by the Now Playing overlay's
+ * artist-line click to jump to a podcast show's MPSP page when the
+ * current track is an episode.
+ */
+export function registerOpenPlaylist(handler: PlaylistNavHandler | null): void {
+  openPlaylistHandler = handler;
+}
+
+export function openPlaylist(playlistId: string): void {
+  openPlaylistHandler?.(playlistId);
 }

--- a/src/lib/showCoverRegistry.ts
+++ b/src/lib/showCoverRegistry.ts
@@ -1,0 +1,34 @@
+// Side-channel for podcast / show cover URLs, keyed by the show's MPSP*
+// browseId. Populated by PlaylistDetailPage whenever the user opens an
+// MPSP playlist; consulted by the now-playing Cover when the active
+// playlist context is a show.
+//
+// Why this exists rather than using `trackArtworkRegistry`:
+//   - The track-artwork registry is keyed per videoId AND filters URLs
+//     down to `lh*|yt3.googleusercontent.com`. Show channel covers are
+//     sometimes served from other hosts (e.g. `youtube-podcasts-
+//     ingestion-proxy`, `i.ytimg.com/sb/...`), so the strict filter
+//     drops them silently and the playing page loses the fallback.
+//   - The channel-page hero renders the show cover via `<CachedImage>`
+//     with NO host filter — the same URL we want on the playing page.
+//     This registry stores that URL directly without further checks.
+//
+// In-memory only — entries last for the session. One entry per show.
+
+const registry = new Map<string, string>();
+
+export function rememberShowCover(
+  playlistId: string | null | undefined,
+  url: string | null | undefined,
+): void {
+  if (!playlistId || !url) return;
+  if (!playlistId.startsWith('MPSP')) return;
+  registry.set(playlistId, url);
+}
+
+export function lookupShowCover(
+  playlistId: string | null | undefined,
+): string | undefined {
+  if (!playlistId) return undefined;
+  return registry.get(playlistId);
+}

--- a/src/lib/trackMetaRegistry.ts
+++ b/src/lib/trackMetaRegistry.ts
@@ -1,0 +1,56 @@
+// Side-channel for per-track metadata (title + artist), keyed by videoId.
+//
+// Why this exists:
+//   The bridge JS scrapes the YTM queue via `.song-title` / `.byline`
+//   selectors that match SONG queue items but NOT podcast / show
+//   episode queue items (those use a different DOM shape). Episode
+//   rows therefore arrive in PlayerState's queue with empty `title`
+//   and `artist`, and `<QueueRow>` shows "Unknown title" with no
+//   byline.
+//
+//   `PlaylistDetailPage` already fetches the show's full episode list
+//   via `parse_playlist_detail` (which uses `parse_episode_from_multi_row`
+//   for episodes) — that data has proper episode title + show-name
+//   artist for each row. Stashing it here lets the queue surface
+//   recover the correct text without reaching back through Rust.
+//
+// In-memory only — entries last for the session.
+
+import type { TrackInfo } from './types';
+
+interface Meta {
+  title: string;
+  artist: string;
+}
+
+const registry = new Map<string, Meta>();
+
+export function rememberTrackMeta(
+  videoId: string | null | undefined,
+  title: string | null | undefined,
+  artist: string | null | undefined,
+): void {
+  if (!videoId) return;
+  // Only insert when we have at least a non-empty title — that's the
+  // load-bearing field for the queue row (artist can legitimately be
+  // empty on some sources; title can't).
+  const safeTitle = (title ?? '').trim();
+  if (!safeTitle) return;
+  registry.set(videoId, {
+    title: safeTitle,
+    artist: (artist ?? '').trim(),
+  });
+}
+
+export function rememberTrackMetas(tracks: ReadonlyArray<TrackInfo>): void {
+  for (const t of tracks) {
+    rememberTrackMeta(t.videoId, t.title, t.artist);
+  }
+}
+
+export function lookupTrackMeta(
+  videoId: string | null | undefined,
+): Meta | undefined {
+  if (!videoId) return undefined;
+  return registry.get(videoId);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -98,6 +98,9 @@ export interface PlaylistDetail {
   /** Release year — present for albums / EPs / singles, absent for
    *  most playlists, charts, and mood mixes. */
   year?: string;
+  /** Header-credited artist (album response often omits per-track
+   *  artist, so this is the canonical fallback). */
+  artist?: string;
 }
 
 export interface SearchResults {
@@ -105,6 +108,9 @@ export interface SearchResults {
   albums: AlbumSummary[];
   artists: ArtistSummary[];
   playlists: PlaylistSummary[];
+  /** Podcast / show shelves — populated only when the caller passes the
+   *  podcasts filter param; absent in the unified (no-filter) view. */
+  podcasts?: PodcastSummary[];
   /**
    * First real album surfaced from an unfiltered search response. Used by the
    * unified search view to render an AlbumCard hero with a 3-track preview.


### PR DESCRIPTION
## Summary

- **Podcasts surface parity** — show covers now render across the now-playing overlay, the chrome card, and every queue row; podcast search has its own tab; queue rows recover episode title + show-name artist when the bridge DOM scrape comes back empty.
- **Detail-page polish** — playlist / album / artist heroes get a sticky transparent + backdrop-blur treatment; albums show the credited artist as a prominent subtitle; clicking the artist on the playing page routes to ArtistPage for songs and the show's MPSP page for episodes.
- **Layout + chrome** — player chrome capsule has symmetric `--space-6` gutters; lyrics button disables while a podcast is the active source; `activePlaylistId` now refreshes per track-change so context-gated UI flips correctly.

## Test plan

- [ ] Open a show (any MPSP browseId), play an episode → channel art appears in:
  - [ ] Now-playing overlay cover
  - [ ] Player chrome's now-playing card thumbnail
  - [ ] Every queue row thumbnail
- [ ] Same flow → queue rows show episode title + show name (no "Unknown title")
- [ ] Click artist line on the playing page during an episode → opens the show's detail page
- [ ] Click artist line on the playing page during a song → opens the artist page
- [ ] Lyrics button is disabled while a podcast/show is playing, enabled for songs
- [ ] Switching from a podcast to a song re-enables the lyrics button (verifies activePlaylistId refresh)
- [ ] Search → Podcasts tab returns shows (open one to confirm it routes to PlaylistDetailPage)
- [ ] Album detail page shows artist subtitle under the title
- [ ] Playlist with multiple artists shows "Various artists" subtitle
- [ ] Open Library → Artists → click a "<native> - <romanized>" entry → ArtistPage shows songs/albums (regression test for matchesArtist)
- [ ] Player chrome capsule has equal-width gaps from the sidebar's right edge and the window's right edge
- [ ] Sticky hero on playlist/album/artist detail pages remains pinned during scroll, with a frosted-glass blur showing scrolled content beneath

🤖 Generated with [Claude Code](https://claude.com/claude-code)