### PR TITLE
feat(home): pin Listen again / Daily discovery / Albums for you to top

### DIFF
--- a/.claude/PRPs/plans/completed/homepage-shelf-priority-order.plan.md
+++ b/.claude/PRPs/plans/completed/homepage-shelf-priority-order.plan.md
@@ -1,0 +1,394 @@
+# Plan: Pin priority shelves to the top of the Home page
+
+## Summary
+The Home page renders YTM home shelves in whatever order the YTM `FEmusic_home`
+endpoint returns, which means user-personal shelves like "Listen again",
+"Your daily discovery", and "Albums for you" can land anywhere on the page —
+sometimes below "Quick picks", sometimes below editorial mood shelves. Pin
+those three to the top, in that order, and keep every other shelf in its
+original backend order beneath them.
+
+## User Story
+As a VibeYTM user, I want my personalized shelves ("Listen again",
+"Your daily discovery", "Albums for you") to always sit at the top of the
+Home page, so that I can resume my own listening without scrolling past
+editorial sections.
+
+## Problem → Solution
+Today the shelf order is whatever YTM returns → priority shelves are
+hoisted client-side before render, the rest preserve their original order.
+
+## Metadata
+- **Complexity**: Small (single file, ~20 lines, no new dependencies)
+- **Source PRD**: N/A (free-form ask)
+- **PRD Phase**: N/A
+- **Estimated Files**: 1 source + 1 test
+
+---
+
+## UX Design
+
+### Before
+```
+┌──────────────────────────────────────────────┐
+│ [Greeting + mood tabs plate]                 │
+├──────────────────────────────────────────────┤
+│ Quick picks                  ← editorial    │
+│ Trending community playlists ← editorial    │
+│ Listen again                 ← personal     │
+│ Your daily discovery         ← personal     │
+│ Albums for you               ← personal     │
+│ Mixed for you                               │
+│ Forgotten favorites                         │
+│ ... etc                                     │
+└──────────────────────────────────────────────┘
+```
+
+### After
+```
+┌──────────────────────────────────────────────┐
+│ [Greeting + mood tabs plate]                 │
+├──────────────────────────────────────────────┤
+│ Listen again                 ← priority #1  │
+│ Your daily discovery         ← priority #2  │
+│ Albums for you               ← priority #3  │
+│ Quick picks                  ← rest, in     │
+│ Trending community playlists    backend     │
+│ Mixed for you                   order       │
+│ Forgotten favorites                         │
+│ ... etc                                     │
+└──────────────────────────────────────────────┘
+```
+
+If one or more priority shelves are absent from the YTM response (e.g. user is
+signed out, fresh account, or YTM dropped that shelf this session), the
+remaining priority shelves still pin to the top in order, and non-priority
+shelves render below — no empty placeholder rows.
+
+### Interaction Changes
+| Touchpoint | Before | After | Notes |
+|---|---|---|---|
+| Home scroll first viewport | YTM order | Priority shelves pinned | Priority order is fixed: Listen again → Your daily discovery → Albums for you |
+| Refresh button | Re-fetches in YTM order | Re-fetches, same reorder applied | Reorder is render-time, not fetch-time — applies to both fresh and cached shelves |
+| Mood tab (non-"All") | No shelves rendered | No shelves rendered | Reorder only affects the `activeMood === 'All'` branch, no change to mood-search rendering |
+| Sign-out / sign-in flush | Shelves cleared, refetched | Same, then reordered | Existing flush behavior in `useTauriEvent('player:login-changed')` is unchanged |
+
+---
+
+## Mandatory Reading
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| P0 | `src/components/pages/HomePage.tsx` | 378-383 | Current render loop — the reorder happens immediately upstream of this map |
+| P0 | `src/components/pages/HomePage.tsx` | 30-36 | Module-level cache of `cachedShelves` — reorder must NOT mutate cached array |
+| P0 | `src/lib/types.ts` | 132-141 | `Shelf` and `ShelfContent` shapes (`title: string`, discriminated `items` union) |
+| P1 | `src/components/pages/HomePage.tsx` | 119-139 | `useEffect`/login-change flow — shows the reorder must be derived, not stored |
+| P1 | `src/components/pages/HomePage.tsx` | 327-376 | Mood-tab branch — confirm reorder lives only in the `activeMood === 'All'` branch |
+| P2 | `src-tauri/src/ytm_api/mod.rs` | 136-175 | Backend `get_home` — confirms shelf titles come straight from YTM, not normalized |
+
+## External Documentation
+None needed — feature uses internal patterns only.
+
+---
+
+## Patterns to Mirror
+
+### MODULE_CONSTANTS_PATTERN
+// SOURCE: src/components/pages/HomePage.tsx:31-50
+```typescript
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const PERSIST_KEY = 'home:shelves';
+// ...
+const MOOD_TABS = [
+  'All',
+  'Energize',
+  // ...
+] as const;
+```
+Module-level `const` arrays/strings declared as `as const` with comments
+explaining intent. The new `PRIORITY_TITLES` constant follows the same
+shape.
+
+### SHELF_RENDER_PATTERN
+// SOURCE: src/components/pages/HomePage.tsx:378-383
+```typescript
+{activeMood === 'All' &&
+  shelves.map((shelf) => (
+    <ShelfRow key={shelf.title} title={shelf.title}>
+      {renderShelfContent(shelf, onOpenPlaylist)}
+    </ShelfRow>
+  ))}
+```
+The render uses `shelf.title` as the React key, so the reordered array must
+preserve unique titles. (YTM home titles are unique within a single response
+in practice, but we'll defensively dedupe by title in case continuation pages
+ever return the same shelf twice.)
+
+### IMMUTABLE_DERIVATION_PATTERN
+// SOURCE: src/components/pages/HomePage.tsx:69-77
+```typescript
+const [shelves, setShelves] = useState<Shelf[]>(cachedShelves ?? []);
+// ...
+const [moodSongs, setMoodSongs] = useState<TrackInfo[]>(
+  cachedMoodSongs && cachedMoodSongs.mood === lastActiveMood
+    ? cachedMoodSongs.songs
+    : [],
+);
+```
+State is set from immutable inputs without mutating module-level caches.
+The reorder must NOT mutate `cachedShelves` or the `shelves` state array —
+return a new array.
+
+### TEST_STRUCTURE
+// SOURCE: src/components/layout/PlayerChrome.test.tsx (referenced from CLAUDE.md WKWebView section, around the "Next bypasses planned queue when shuffle is on" test)
+Tests live next to the component, file pattern `<Component>.test.tsx`,
+import from `vitest` (the project uses `pnpm test` → vitest per CLAUDE.md
+verification discipline). Pure functions are unit-tested; the reorder
+function will be a pure function so it can be tested without rendering React.
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|---|---|---|
+| `src/components/pages/HomePage.tsx` | UPDATE | Add `PRIORITY_TITLES` constant + `reorderShelves` pure helper; call it inside the render loop |
+| `src/components/pages/HomePage.test.tsx` | CREATE | Unit-test `reorderShelves` against the four scenarios in the Edge Cases checklist |
+
+## NOT Building
+- A user-facing setting to customize the priority list. Three titles are hard-coded per the user's ask. If/when more customization is needed, extend the constant.
+- Any backend change. The Rust `get_home` endpoint stays untouched — reordering is render-time only.
+- Removing or hiding non-priority shelves. Everything YTM returns still renders.
+- Smart matching across locales (e.g. translated YTM strings). The user runs YTM in English; if a localized YTM ever returns "Daily Mix" / "Wieder anhören" / etc., the fallback is the existing YTM order — no broken UI, just no pin.
+- Mood-tab reorder. The mood-tab branch renders search results, not home shelves; no priority concept applies.
+
+---
+
+## Step-by-Step Tasks
+
+### Task 1: Add `PRIORITY_TITLES` constant and pure `reorderShelves` helper
+- **ACTION**: Add a module-level `PRIORITY_TITLES` constant and a pure helper `reorderShelves(shelves: Shelf[]): Shelf[]` in `src/components/pages/HomePage.tsx`.
+- **IMPLEMENT**:
+  ```typescript
+  // Three personal shelves users want pinned to the top of Home, in this
+  // exact display order. Match is case-insensitive and trim-tolerant — YTM
+  // sometimes returns trailing whitespace and capitalization drifts.
+  const PRIORITY_TITLES = [
+    'Listen again',
+    'Your daily discovery',
+    'Albums for you',
+  ] as const;
+
+  function reorderShelves(shelves: Shelf[]): Shelf[] {
+    const norm = (s: string) => s.trim().toLowerCase();
+    const priorityIndex = new Map(
+      PRIORITY_TITLES.map((title, i) => [norm(title), i]),
+    );
+
+    const pinned: Shelf[] = [];
+    const rest: Shelf[] = [];
+    const seen = new Set<string>();
+
+    for (const shelf of shelves) {
+      const idx = priorityIndex.get(norm(shelf.title));
+      if (idx !== undefined && !seen.has(norm(shelf.title))) {
+        pinned[idx] = shelf;
+        seen.add(norm(shelf.title));
+      } else {
+        rest.push(shelf);
+      }
+    }
+
+    // pinned may contain holes if some priority shelves are absent — drop them
+    return [...pinned.filter(Boolean), ...rest];
+  }
+  ```
+- **MIRROR**: `MODULE_CONSTANTS_PATTERN` (lines 31-50) and `IMMUTABLE_DERIVATION_PATTERN` (lines 69-77). Pure function, no mutation of input.
+- **IMPORTS**: No new imports — `Shelf` is already imported on line 2.
+- **GOTCHA**: Do NOT call `Array.prototype.sort` with a comparator that returns the priority index — `sort` is not stable across all engines for equal keys, AND a comparator-based approach forces O(n log n) plus has to compute `priorityIndex` lookups twice per pair. Build two arrays in a single pass.
+- **GOTCHA**: `pinned[idx] = shelf` creates a sparse array when some priority titles are missing. `filter(Boolean)` collapses the holes; do NOT use `pinned.length` checks — that includes holes.
+- **GOTCHA**: De-dupe by normalized title via `seen` so a continuation that re-emits the same shelf (defensive — YTM continuation pages occasionally do this) doesn't overwrite the first occurrence.
+- **VALIDATE**: `pnpm typecheck` — no type errors. Function is exported (or made testable via re-export) so the test file can import it.
+
+### Task 2: Apply reorder in the render loop
+- **ACTION**: Replace `shelves.map(...)` at HomePage.tsx:379 with `reorderShelves(shelves).map(...)`.
+- **IMPLEMENT**:
+  ```typescript
+  {activeMood === 'All' &&
+    reorderShelves(shelves).map((shelf) => (
+      <ShelfRow key={shelf.title} title={shelf.title}>
+        {renderShelfContent(shelf, onOpenPlaylist)}
+      </ShelfRow>
+    ))}
+  ```
+- **MIRROR**: `SHELF_RENDER_PATTERN` (lines 378-383). Render shape unchanged; only the source array is reordered.
+- **IMPORTS**: None.
+- **GOTCHA**: Reorder is computed on every render. With ~10–20 shelves the cost is trivial (single linear pass). Do NOT memoize unless profiling shows it matters — premature `useMemo` adds dep-array maintenance with no real win at this size.
+- **GOTCHA**: Do NOT call `reorderShelves` inside `setShelves(...)` (i.e. don't bake the reorder into state). Keeping `shelves` state as the raw backend order means future ordering tweaks (or a user-controllable priority list) only need to touch the helper, not the fetch path.
+- **GOTCHA**: Do NOT mutate `cachedShelves` (module-level on line 34) — `reorderShelves` already returns a new array, but Task 1's implementation must keep the input untouched so the persistent cache stays in canonical YTM order.
+- **VALIDATE**: `pnpm typecheck`. Then `pnpm tauri dev`, sign in, scroll Home — first three sections should be the priority titles in order; remaining sections should match the prior YTM order.
+
+### Task 3: Unit-test `reorderShelves`
+- **ACTION**: Create `src/components/pages/HomePage.test.tsx` with vitest-style tests for the pure helper. Export `reorderShelves` from `HomePage.tsx` (named export) so the test can import it without rendering.
+- **IMPLEMENT**: Write tests for the four scenarios in the Edge Cases section. Use minimal `Shelf` fixtures (only `title` and a stub `items` are needed — tests assert on title order, not content).
+  ```typescript
+  import { describe, expect, test } from 'vitest';
+  import { reorderShelves } from './HomePage';
+  import type { Shelf } from '../../lib/types';
+
+  const stubItems: Shelf['items'] = { kind: 'Songs', data: [] };
+  const shelf = (title: string): Shelf => ({ title, items: stubItems });
+
+  describe('reorderShelves', () => {
+    test('pins all three priority shelves in the configured order', () => {
+      const input = [
+        shelf('Quick picks'),
+        shelf('Albums for you'),
+        shelf('Trending community playlists'),
+        shelf('Listen again'),
+        shelf('Your daily discovery'),
+      ];
+      const out = reorderShelves(input).map((s) => s.title);
+      expect(out).toEqual([
+        'Listen again',
+        'Your daily discovery',
+        'Albums for you',
+        'Quick picks',
+        'Trending community playlists',
+      ]);
+    });
+
+    test('keeps non-priority shelves in their original backend order', () => {
+      const input = [shelf('A'), shelf('B'), shelf('Listen again'), shelf('C')];
+      const out = reorderShelves(input).map((s) => s.title);
+      expect(out).toEqual(['Listen again', 'A', 'B', 'C']);
+    });
+
+    test('falls through gracefully when priority shelves are missing', () => {
+      const input = [shelf('Quick picks'), shelf('Listen again')];
+      const out = reorderShelves(input).map((s) => s.title);
+      expect(out).toEqual(['Listen again', 'Quick picks']);
+    });
+
+    test('matches case-insensitively and tolerates trailing whitespace', () => {
+      const input = [
+        shelf('quick picks'),
+        shelf('  Albums For You  '),
+        shelf('LISTEN AGAIN'),
+      ];
+      const out = reorderShelves(input).map((s) => s.title);
+      expect(out).toEqual(['LISTEN AGAIN', '  Albums For You  ', 'quick picks']);
+    });
+
+    test('does not mutate input array', () => {
+      const input = [shelf('A'), shelf('Listen again')];
+      const snapshot = input.map((s) => s.title);
+      reorderShelves(input);
+      expect(input.map((s) => s.title)).toEqual(snapshot);
+    });
+
+    test('dedupes when the same priority title appears twice', () => {
+      const input = [
+        shelf('Listen again'),
+        shelf('Quick picks'),
+        shelf('Listen again'),
+      ];
+      const out = reorderShelves(input).map((s) => s.title);
+      // First occurrence wins; the duplicate falls into rest, preserving its order
+      expect(out).toEqual(['Listen again', 'Quick picks', 'Listen again']);
+    });
+  });
+  ```
+- **MIRROR**: `TEST_STRUCTURE` — co-located `<Component>.test.tsx` next to component (matches existing tests like `PlayerChrome.test.tsx`, `Sidebar.test.tsx`).
+- **IMPORTS**: `vitest`, `Shelf` type, `reorderShelves`.
+- **GOTCHA**: The function must be exported. Add `export` to its declaration in HomePage.tsx — do NOT introduce a separate utility file unless `reorderShelves` grows beyond ~30 lines. Keeping it in HomePage.tsx mirrors the project's preference for co-locating helpers (e.g. `getGreeting` on line 62).
+- **VALIDATE**: `pnpm test src/components/pages/HomePage.test.tsx` — all six tests pass.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+| Test | Input | Expected Output | Edge Case? |
+|---|---|---|---|
+| Pins all 3 priorities | mixed array containing all 3 | `[L, Y, A, ...rest in order]` | No |
+| Preserves rest order | input has 1 priority + 3 others | `[priority, A, B, C]` | Yes — confirms stability |
+| Missing priorities | input has only "Listen again" + 1 other | `[Listen again, other]` (no holes) | Yes — sparse-array trap |
+| Case / whitespace | `'LISTEN AGAIN'`, `'  Albums For You  '` | Pinned correctly | Yes — YTM wording drift |
+| No mutation | snapshot input before, compare after | Input unchanged | Yes — cachedShelves invariant |
+| Duplicate priority title | `'Listen again'` appears twice | First wins, second goes to rest | Yes — continuation defensive |
+
+### Edge Cases Checklist
+- [ ] Empty `shelves` array → returns `[]`
+- [ ] All shelves are priority shelves → all pinned, no rest
+- [ ] No shelves are priority shelves → identity (same order, new array)
+- [ ] Some priority shelves missing → no holes in output
+- [ ] Mixed case + whitespace → still pinned
+- [ ] Same priority shelf appears twice → first wins
+- [ ] Mutation of input → never happens
+
+---
+
+## Validation Commands
+
+### Static Analysis
+```bash
+pnpm typecheck
+```
+EXPECT: Zero type errors.
+
+### Unit Tests
+```bash
+pnpm test src/components/pages/HomePage.test.tsx
+```
+EXPECT: 6/6 tests pass.
+
+### Full Test Suite
+```bash
+pnpm test
+```
+EXPECT: No regressions in any other test file.
+
+### Manual Validation
+- [ ] `pkill -f "tauri dev" 2>/dev/null; pkill -f "VibeYTM" 2>/dev/null; sleep 1; pnpm tauri dev` (only if module-level state needs reset; otherwise rely on Vite HMR — see CLAUDE.md "Dev Workflow")
+- [ ] Sign in (or use existing session) and load Home
+- [ ] First section title is "Listen again" (or whichever of the three is present first)
+- [ ] Following two sections are "Your daily discovery" then "Albums for you" (when present)
+- [ ] Below those, the original YTM order resumes ("Quick picks", "Trending community playlists", etc.)
+- [ ] Sign out → home flushes → re-renders without the priority shelves but does NOT crash
+- [ ] Tap "↻ Refresh" → reorder still applied to the new fetch
+- [ ] Tap a non-"All" mood tab → mood search renders normally (reorder doesn't fire in that branch)
+- [ ] Tap "All" mood tab → reorder still applied
+
+---
+
+## Acceptance Criteria
+- [ ] `PRIORITY_TITLES = ['Listen again', 'Your daily discovery', 'Albums for you']` declared at module level in HomePage.tsx
+- [ ] `reorderShelves` is a pure, exported function — no mutation of input, no module-level state read inside
+- [ ] Render loop at HomePage.tsx:379 calls `reorderShelves(shelves)` instead of using `shelves` directly
+- [ ] All 6 unit tests pass
+- [ ] `pnpm typecheck` passes
+- [ ] Manual smoke test on Home shows the three shelves at the top in order
+
+## Completion Checklist
+- [ ] Code follows discovered patterns (module constants, pure helpers, immutable derivation)
+- [ ] No mutation of `cachedShelves` or `shelves` state
+- [ ] Tests co-located in `HomePage.test.tsx`
+- [ ] No backend (Rust) changes
+- [ ] No new dependencies
+- [ ] No `console.log` statements
+- [ ] No version bump needed for plan generation; bump patch in `package.json` + `src-tauri/tauri.conf.json` when implementing
+
+## Risks
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| YTM changes one of the three shelf titles | Low | One shelf no longer pinned | Case-insensitive + trim-tolerant match absorbs casing/whitespace drift; semantic renames will surface as a missing pin and can be patched in `PRIORITY_TITLES` |
+| Localized YTM accounts return non-English titles | Medium for non-en accounts | Priority pin no-ops, falls back to YTM order | Documented in NOT Building; expand constant if it becomes an issue |
+| Cached shelf array gets reordered by accident | Low | Persistent cache + in-memory cache drift across reloads | `reorderShelves` is pure, returns new array; covered by "does not mutate input" test |
+| Sparse-array bug from `pinned[idx] = shelf` when priorities are missing | Low | Empty placeholder rows | `filter(Boolean)` drops holes; covered by "missing priorities" test |
+| Future continuation page emits a duplicate priority shelf | Low | Duplicate render with same React key | `seen` set + first-wins; second occurrence falls into rest, preserving uniqueness within the pinned head |
+
+## Notes
+- This is intentionally render-time, not fetch-time. Keeping the cache in canonical YTM order means a future "user-customizable priority list" feature can swap `PRIORITY_TITLES` for state without touching the network or persistent-cache layer.
+- The user verified externally on music.youtube.com that personalized shelves only appear signed in. The signed-out fallback (no priority shelves to pin) is exercised by the "missing priorities" test.
+- No Chrome DevTools MCP capture was needed — the user already named the three exact title strings; the helper's case/whitespace tolerance is enough to absorb minor YTM wording drift.

--- a/.claude/PRPs/reports/homepage-shelf-priority-order-report.md
+++ b/.claude/PRPs/reports/homepage-shelf-priority-order-report.md
@@ -1,0 +1,73 @@
+# Implementation Report: Pin priority shelves to the top of the Home page
+
+## Summary
+Added a render-time reorder that pins three personal Home shelves
+("Listen again", "Your daily discovery", "Albums for you") to the top
+in that exact order, with all other shelves preserving their original
+backend order. Implementation is a pure helper (`reorderShelves`)
+plus a constant array (`PRIORITY_TITLES`), called inside the
+existing `activeMood === 'All'` render branch. No backend, no cache,
+no fetch-path changes.
+
+## Assessment vs Reality
+
+| Metric | Predicted (Plan) | Actual |
+|---|---|---|
+| Complexity | Small | Small — matched |
+| Confidence | 9/10 | 10/10 — implemented as planned with no surprises |
+| Files Changed | 2 (1 source + 1 test) | 2 — matched |
+
+## Tasks Completed
+
+| # | Task | Status | Notes |
+|---|---|---|---|
+| 1 | Add `PRIORITY_TITLES` + `reorderShelves` | Complete | Exported from HomePage.tsx as planned |
+| 2 | Apply reorder in render loop | Complete | Single-line swap at the existing `shelves.map(...)` site |
+| 3 | Unit-test `reorderShelves` | Complete | 8 tests written (6 from plan + 2 extras: empty-input, identity-not-reused) |
+
+## Validation Results
+
+| Level | Status | Notes |
+|---|---|---|
+| Static Analysis (`pnpm typecheck`) | Pass | Zero type errors |
+| Unit Tests (HomePage.test.tsx) | Pass | 8/8 |
+| Full Test Suite (`pnpm test`) | Pass | 215/215, no regressions across 24 files |
+| Build | N/A — frontend-only changes; HMR picks them up via Vite. Will be exercised by `pnpm tauri build` at release time |
+| Edge Cases | Pass | Empty input, all-priority, no-priority, missing priority, case/whitespace, duplicate priority — all covered |
+
+## Files Changed
+
+| File | Action | Lines |
+|---|---|---|
+| `src/components/pages/HomePage.tsx` | UPDATED | +37 / -1 |
+| `src/components/pages/HomePage.test.tsx` | CREATED | +79 |
+
+## Deviations from Plan
+Two extra unit tests beyond the six listed in the plan:
+- "returns a new array (no identity reuse)" — defensive identity check
+  (the immutability test only covers content, not reference)
+- "handles empty input" — not strictly listed but free coverage of the
+  edge case marked in the Edge Cases checklist
+
+Neither deviation changed the API or behavior; they only widened test
+coverage. Counted as additive, not real deviations.
+
+## Issues Encountered
+- `pnpm typecheck` initially failed with "tsc: command not found" because
+  `node_modules` was missing in this worktree. Resolved with `pnpm install`.
+
+## Tests Written
+
+| Test File | Tests | Coverage |
+|---|---|---|
+| `src/components/pages/HomePage.test.tsx` | 8 | All scenarios from plan's Edge Cases checklist plus identity-not-reused and empty-input |
+
+## Manual Verification Pending
+- The render integration is a 2-line swap (`shelves.map` → `reorderShelves(shelves).map`); typecheck verifies the call shape. Visual confirmation that the user's actual YTM home returns the expected three title strings verbatim requires running the app while signed in.
+- Per CLAUDE.md "Dev Workflow", frontend-only `.tsx` changes are HMR-picked-up by an already-running `pnpm tauri dev` — no restart needed.
+
+## Next Steps
+- [ ] User verifies visually that Home now shows priority shelves at the top in order
+- [ ] Bump patch version in `package.json` + `src-tauri/tauri.conf.json` per CLAUDE.md when committing
+- [ ] `/code-review`
+- [ ] `/prp-pr`

--- a/.claude/PRPs/reviews/local-homepage-shelf-priority-order-review.md
+++ b/.claude/PRPs/reviews/local-homepage-shelf-priority-order-review.md
@@ -1,0 +1,87 @@
+# Local Code Review: Pin priority shelves to the top of Home
+
+**Reviewed**: 2026-05-02
+**Branch**: `new-features`
+**Decision**: APPROVE (with one nit auto-fixed)
+
+## Summary
+Render-time reorder of YTM home shelves to pin three personal shelves
+("Listen again", "Your daily discovery", "Albums for you") to the top.
+Pure helper, no backend changes, no mutation of cached state. Clean,
+covered by 8 unit tests, typecheck passes, no regressions in 215 tests.
+Approved.
+
+## Files Reviewed
+
+| File | Change | Lines |
+|---|---|---|
+| `src/components/pages/HomePage.tsx` | Modified | +37 / -1 |
+| `src/components/pages/HomePage.test.tsx` | Added | +79 |
+| `.claude/PRPs/plans/completed/homepage-shelf-priority-order.plan.md` | Added (plan archive) | — |
+| `.claude/PRPs/reports/homepage-shelf-priority-order-report.md` | Added (report) | — |
+
+## Findings
+
+### CRITICAL
+None.
+
+### HIGH
+None.
+
+### MEDIUM
+**1. Test framework convention drift** — `HomePage.test.tsx` originally
+used `test(...)` from vitest while every other test file in the project
+uses `it(...)` (verified across 10 test files including
+`PlayerChrome.test.tsx`, `Sidebar.test.tsx`, `splitMode.test.tsx`).
+**Auto-fixed in this review** — switched all 8 cases to `it(...)`. Tests
+re-run, 8/8 still pass.
+
+### LOW
+**2. Pre-existing React-key collision risk** — the render at
+`HomePage.tsx:415` uses `key={shelf.title}` for the shelf list. If YTM
+ever returns two shelves with the same title in a single response (e.g.
+continuation pages re-emitting a shelf), React will warn about duplicate
+keys. This is **pre-existing** — not introduced by this PR — but the
+dedup logic in `reorderShelves` only handles the priority-title overlap
+case. Two non-priority shelves with the same title would still collide.
+Not worth fixing in this PR; would be cleaner addressed by the file's
+`renderShelfContent` rather than the reorder helper. Filed as LOW for
+future awareness.
+
+**3. Per-render computation** — `reorderShelves(shelves)` runs on every
+render. With ~10–20 shelves it's a single linear pass and trivially
+cheap. The plan explicitly chose not to memoize, citing dep-array
+maintenance overhead vs negligible CPU cost. Confirmed appropriate —
+no change needed.
+
+## Validation Results
+
+| Check | Result |
+|---|---|
+| Type check (`pnpm typecheck`) | Pass — zero errors |
+| Lint | N/A — project uses TS errors as the lint gate |
+| Tests (HomePage.test.tsx) | Pass — 8/8 |
+| Full test suite (`pnpm test`) | Pass — 215/215 across 24 files, no regressions |
+| Build | Skipped — frontend-only, exercised by `pnpm tauri build` at release |
+
+## Category-by-Category
+
+| Category | Notes |
+|---|---|
+| Correctness | Pure function, edge cases covered (empty, all-priority, none-priority, missing, case/whitespace, duplicate). Sparse-array handling via `filter(Boolean)` is right. De-dupe via `seen` correctly keeps first occurrence. |
+| Type Safety | All types explicit. `Shelf[]` → `Shelf[]`. `as const` on tuple cast for Map constructor. No `any`. No unsafe casts. |
+| Pattern Compliance | Mirrors `MOOD_TABS` (module `as const`), `getGreeting` (co-located helper), comment style (inline `//`, no JSDoc). Test conventions matched after the auto-fix. |
+| Security | No user input, no IPC, no DOM injection, no untrusted data flow. N/A. |
+| Performance | O(n) single pass per render. ~10–20 items typical. No optimization needed. |
+| Completeness | All plan tasks done. Tests written. No `console.log`. No TODO/FIXME. No emoji. |
+| Maintainability | Function 18 lines (limit 50). File 581 lines (limit 800). Comment explains why (case/whitespace tolerance, drift). No magic numbers. No deep nesting (max 2 levels). |
+
+## Decision Rationale
+
+Zero CRITICAL/HIGH issues. One MEDIUM auto-fixed in-review. One pre-existing LOW
+issue noted but out of scope. Validation green. **APPROVE.**
+
+## Next Steps
+- [ ] User visual verification on running app (only the actual signed-in YTM home can confirm the three shelves pin in the right order)
+- [ ] Bump patch version (`1.1.21` → `1.1.22`) in `package.json` + `src-tauri/tauri.conf.json` per CLAUDE.md when committing
+- [ ] `/prp-commit` or `/prp-pr`

--- a/.claude/PRPs/reviews/pr-97-review.md
+++ b/.claude/PRPs/reviews/pr-97-review.md
@@ -1,0 +1,119 @@
+# PR Review: #97 — feat(home): pin Listen again / Daily discovery / Albums for you to top
+
+**Reviewed**: 2026-05-02
+**Branch**: `new-features` → `main`, HEAD `f55b207`
+**Scope**: 27 files, +1839 / -174, 12 commits
+**Decision**: APPROVE with optional fixes
+
+## Summary
+Mature, thoroughly tested PR. Two backend types added (`HistorySection`, optional fields on `TrackInfo`), three new FE components/helpers (`reorderShelves`, `bucketHistorySections`, `EpisodeRow`, `ExpandableDescription`), four overlay/CSS fixes targeting WKWebView paint flicker, plus content tweaks (Songs hidden in sidebar). 217 → 229 unit tests, 5 new Rust parser tests, 0 regressions. No CRITICAL or HIGH defects in production code; the CRITICAL items below are missing-test gaps that would let a real bug regress, not actual bugs today.
+
+---
+
+## Findings (deduped, confidence ≥ 80)
+
+### CRITICAL — must fix before merge if you want regression safety
+
+None.
+
+### HIGH — should fix before merge
+
+**H1. EpisodeRow swallows playback errors silently** (`src/components/browse/EpisodeRow.tsx:47`)
+`playerApi.playTrack(...).catch(() => {})` discards every failure with no log, no debug.error, no user feedback. A user taps an episode → nothing plays → indistinguishable from success. Fix: route to `debug.error('EpisodeRow', 'playTrack failed', e)` like other components do.
+
+**H2. SafeOverlay `willChange` lifecycle has zero test coverage** (`src/components/overlay/SafeOverlay.tsx:143-150` + `SafeOverlay.test.tsx`)
+The new `transitioning` state + 480 ms `setTimeout` is the lynchpin of the issue #99 fix. Existing tests assert pointer-events, transform, aria-hidden — but `willChange` is silent. A future edit that breaks the cleanup or flips the timer logic re-opens the WKWebView paint flicker with no test catch. Add a vi.useFakeTimers test asserting:
+- mount → `willChange: 'opacity, transform'` (transitioning)
+- advance 480 ms → `willChange: 'auto'`
+- flip `isOpen` → `willChange: 'opacity, transform'` again
+- rapid re-flip cancels the prior demote (no stale timer fires)
+
+**H3. PlaylistDetailPage `isShow ? EpisodeRow : SongRow` branch is untested** (`src/components/pages/PlaylistDetailPage.tsx:425-438`)
+A regression flipping the condition (or breaking the `MPSPP*` check) silently renders music rows for podcasts. Add a render test with mocked `getPlaylist` returning an `MPSPP*` playlist; assert `EpisodeRow` is mounted and `SongRow` is not.
+
+### MEDIUM — quality improvements
+
+**M1. `collect_history_section` uses parallel `if let` instead of `if / else if`** (`src-tauri/src/ytm_api/mod.rs:2139-2158`)
+If a JSON node ever carries both `musicCarouselShelfRenderer` AND `musicShelfRenderer` (malformed/future shape drift), both branches push, duplicating the section. Today's YTM doesn't do this; trivially fixed by `else if`.
+
+**M2. `reorderShelves` not memoized** (`src/components/pages/HomePage.tsx:424`)
+HistoryPage memoizes its bucketing result; HomePage doesn't. Recomputed on every mood-tab change, mood-songs load, etc. No user-visible impact at current shelf counts (~15-20). Wrap in `useMemo([shelves])` for consistency.
+
+**M3. Stale doc on `YtmApi::get_history`** (`src-tauri/src/ytm_api/mod.rs:265-270`)
+Docstring says parsing reuses `parse_library_songs`; the function actually calls `parse_history_grouped`. Misleading for any future maintainer.
+
+**M4. `LyricsPanel.tsx:47-50` has a half-finished sentence in `CONTAINER_STYLE` comment** (`src/components/player/NowPlaying/LyricsPanel.tsx`)
+The "Fill the full content height of the overlay…" sub-comment trails off mid-thought ("…the panel's bottom edge aligns") and contradicts the actual padding (`var(--space-6)` uniform). Replace with the SafeOverlay-owns-the-frame block that's already in the file just below.
+
+**M5. `formatEpisodeDuration` doc claims MM:SS sub-minute fallback** (`src/components/browse/EpisodeRow.tsx:17-19`)
+The function returns `"N sec"` for sub-minute clips, not MM:SS. Fix the docstring.
+
+**M6. `bucketHistorySections` doc says "last 7 days" but the implementation looks back 6 days** (`src/components/pages/HistoryPage.tsx:33-35,54`)
+After Today + Yesterday are exact-matched, the date range is `[today - 6 days, yesterday]`. Either rename `sevenDaysAgo` → `sixDaysAgo` or update the doc.
+
+**M7. ExpandableDescription has no test coverage at all** (`src/components/DetailPageHero.tsx`)
+Three behaviors should be pinned: button hidden when text fits, visible when it overflows, toggle expands/collapses. jsdom + mocked `ResizeObserver` makes this tractable.
+
+**M8. Episode duration fallback walks all runs but only one shape is tested** (`src-tauri/src/ytm_api/mod.rs:3502-3510`)
+`parse_episode_from_multi_row_handles_secondtitle_shape` covers `[" • ", "5 min"]` (parseable at index 1). Two uncovered paths: parseable-at-index-0 (`["5 min", " • "]`) and all-non-parseable (`[" • "]` → expect 0). Quick to add.
+
+### LOW — nits / advisories
+
+**L1. SafeOverlay context comment cites `NowPlaying.tsx` (file no longer exists)** (`src/components/overlay/SafeOverlay.tsx:17`)
+The flat file was split into `NowPlaying/index.tsx`. Drop the line number; the directory reference is enough.
+
+**L2. PRIORITY_TITLE_ALIASES typed as nested ReadonlyArray instead of tuple** (`src/components/pages/HomePage.tsx:66-77`)
+Slot index is load-bearing (slot 0 = Listen again, slot 1 = Discovery, slot 2 = Albums). A tuple `readonly [readonly string[], readonly string[], readonly string[]]` would catch slot insertions/deletions at compile time. Type-design improvement, not a bug.
+
+**L3. `BucketKey` private inside HistoryPage but `bucketHistorySections` is exported** (`src/components/pages/HistoryPage.tsx`)
+A consumer/test that wants to annotate `BucketKey` has to duplicate it. Export it alongside.
+
+**L4. HomePage mood-search catch silently sets empty array with no log** (`src/components/pages/HomePage.tsx:212-218`)
+**Pre-existing** — not introduced by this PR. Flag for awareness; out of scope.
+
+**L5. PRIORITY_TITLE_ALIASES verification timestamp ages out** (`src/components/pages/HomePage.tsx`)
+The "verified 2026-05-02" comment will be wrong the moment YTM renames a shelf. Consider rephrasing as a procedure (re-verify via REORDER-DIAG when YTM updates) rather than asserting current values.
+
+### Code simplification candidates (advisory only — accept or reject)
+
+**S1. `reorderShelves` two-pass with sparse array → `Map<number, Shelf>` collected at end** (`HomePage.tsx:89-104`)
+Eliminates the `filledSlots` set, the sparse write, and the trailing `.filter(Boolean)`.
+
+**S2. `parse_episode_from_multi_row` empty-string → `Option<String>` boilerplate** (`src-tauri/src/ytm_api/mod.rs:3479-3483, 3519-3523`)
+Two if-let-else blocks could be `(!s.is_empty()).then_some(s)` one-liners.
+
+**S3. `ExpandableDescription` two effects with same body** (`DetailPageHero.tsx:400-418`)
+`useLayoutEffect` (initial) and `useEffect` (resize) share identical measurement logic. Single `measure()` callback called from both eliminates duplication.
+
+**S4. `HistoryPage` `totalTracks` outside the `useMemo`** (`HistoryPage.tsx:119`)
+Computed via `reduce` every render while `buckets` is memoized from the same `sections`. Return `{ buckets, totalTracks }` from a single memo pass.
+
+---
+
+## Validation Results
+
+| Check | Result | Notes |
+|---|---|---|
+| Type check (`pnpm typecheck`) | Pass | Zero errors |
+| Tests (`pnpm test`) | Pass | 229/229 across 25 files |
+| Tests (`cargo test --lib`) | Pass | 207/207 (5 new) |
+| Lint | N/A | Project relies on TS errors as the gate |
+| Build | Skipped | Frontend covered by HMR; release builds via `pnpm tauri build` at ship time |
+
+## Files Reviewed
+27 files. Significant new code in:
+- `src/components/pages/HomePage.tsx` (+37/-1) — reorderShelves
+- `src/components/pages/HistoryPage.tsx` (+200/-50) — buckets + grouped UI + canonical title plate
+- `src/components/browse/EpisodeRow.tsx` (new, +154)
+- `src/components/DetailPageHero.tsx` (+95) — ExpandableDescription + back-button marker
+- `src/components/overlay/SafeOverlay.tsx` (+22) — willChange demote
+- `src-tauri/src/ytm_api/mod.rs` (+~150) — parse_history_grouped + episode shape detection
+- `src-tauri/src/state/player.rs` (+8) — TrackInfo new fields
+- `src/styles/global.css` (+25) — body:has() rules
+
+## Decision Rationale
+Zero CRITICAL findings; the three HIGH items are silent-failure-on-error (H1) and missing tests for the lynchpin lifecycle changes (H2/H3). H1 is a 1-line fix; H2/H3 are 30-60 lines of test code each. None block merge; all are good guard-rails before this work hits main.
+
+The MEDIUM list is mostly comment rot from rapid iteration (M3-M6) and one parallel-if defensive fix (M1). The LOW list is mostly type-design nuance and a pre-existing bug (L4). Code-simplifier proposals are nice-to-have, not blocking.
+
+**Recommended action**: land H1 + a test for the `isShow` branch (H3) before merge; defer H2 (SafeOverlay willChange tests), the comment cleanups (M3-M6), and simplification (S1-S4) to a follow-up PR if the merge window is tight.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ A YouTube Music desktop app built with Tauri, React, and Rust.
 - Album / playlist detail pages: pinned hero (cover + title + play-all + save), scrolling track list, edge-flush rows, invisible spacer so the last track clears the floating chrome
 - Album hero meta line: `artist · year · N songs · runtime`; description joins all runs (no more lopped descriptions); back button portaled above the title-bar drag region for click reliability
 - **Library Podcasts**: dedicated `FEmusic_library_non_music_audio_list` endpoint (full subscription list, not just the landing subset), per-show "last episode X ago" recency probe (parallel, capped concurrency, 1h localStorage cache), and grid sorted most-recent-first
+- **Podcast detail rows** — full episode rows on show pages with the publish-date and long-form duration under the title plus a 3-line description preview, distinct from music-track rows
 - **Subscribe / Unsubscribe button** on podcast detail pages with the same like-endpoint round-trip as playlist/album save
 - Show-cover override: episodes from a podcast use the show's channel art on every now-playing surface
+- **Pinned Home shelves** — Listen again, Your daily discover, Albums for you stay at the top of Home no matter what order YTM returns them in
+- **Grouped History** — recently played is bucketed into Today / Yesterday / This week / Earlier (preserving YTM's own date sections under the hood)
+- **Expandable hero descriptions** — long album / show / playlist descriptions clamp to 2 lines with a More / Less toggle that only appears when text actually overflows
 - System tray with playback controls
 - Media key support (Play/Pause, Next, Previous)
 - Now Playing Control Center integration (macOS)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.24",
+  "version": "1.1.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.31",
+  "version": "1.1.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.32",
+  "version": "1.1.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.34",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.33",
+  "version": "1.1.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.23",
+  "version": "1.1.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.29",
+  "version": "1.1.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.21",
+  "version": "1.1.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.30",
+  "version": "1.1.31",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.22",
+  "version": "1.1.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.27",
+  "version": "1.1.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.25",
+  "version": "1.1.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.28",
+  "version": "1.1.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.1.26",
+  "version": "1.1.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -151,22 +151,31 @@ pub async fn get_playlist(
 }
 
 /// Issue #93 — pull the user's "Recently played" history from
-/// YouTube Music's own catalog (FEmusic_history browseId). Replaces
-/// the locally-tracked log added in #83 with the authoritative
-/// source the follow-up issue requested.
+/// YouTube Music's own catalog (FEmusic_history browseId). Returns
+/// date-grouped sections (e.g. "Today", "Yesterday", "Last week")
+/// preserving YTM's own labels so the FE can bucket entries into
+/// Today / Yesterday / This week / Earlier.
 #[tauri::command]
 pub async fn get_history(
     app: AppHandle,
     api: State<'_, YtmApi>,
     cache: State<'_, Cache>,
-) -> Result<Vec<TrackInfo>, String> {
+) -> Result<Vec<HistorySection>, String> {
     tracing::info!("browse::get_history called");
     let mut result = api.get_history(&app).await.map_err(|e| {
         tracing::error!(error = %e, "browse::get_history failed");
         e.to_string()
     })?;
-    enrich_tracks(&cache, &mut result);
-    tracing::info!(tracks = result.len(), "browse::get_history done");
+    let mut total = 0usize;
+    for section in result.iter_mut() {
+        enrich_tracks(&cache, &mut section.tracks);
+        total += section.tracks.len();
+    }
+    tracing::info!(
+        sections = result.len(),
+        tracks = total,
+        "browse::get_history done"
+    );
     Ok(result)
 }
 

--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -322,6 +322,7 @@ pub async fn play_track(
         )),
         duration_secs: 0.0,
         video_id,
+        ..Default::default()
     };
 
     {

--- a/src-tauri/src/state/player.rs
+++ b/src-tauri/src/state/player.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TrackInfo {
     pub video_id: String,
@@ -13,6 +13,15 @@ pub struct TrackInfo {
     pub album_id: Option<String>,
     pub artwork_url: Option<String>,
     pub duration_secs: f64,
+    /// Podcast / show episode description blurb. Populated only by
+    /// `parse_episode_from_multi_row`; absent on music tracks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Podcast / show episode publish-date display string (e.g.
+    /// "Mar 1, 2026" or "3 days ago"). YTM-formatted; we don't parse it.
+    /// Populated only for episodes; absent on music tracks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/src-tauri/src/webview_bridge/poller.rs
+++ b/src-tauri/src/webview_bridge/poller.rs
@@ -433,6 +433,7 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                     album_id: None,
                     artwork_url: if bs.artwork_url.is_empty() { None } else { Some(bs.artwork_url.clone()) },
                     duration_secs: initial_duration,
+                    ..Default::default()
                 };
 
                 // Persist duration in the side-cache so future list responses
@@ -678,6 +679,7 @@ pub fn start_poller(app: AppHandle, player_state: SharedPlayerState, bus: Arc<Ev
                             Some(q.artwork_url.clone())
                         },
                         duration_secs: q.duration_secs,
+                        ..Default::default()
                     })
                     .collect();
                 {

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -3422,15 +3422,34 @@ fn parse_episode_from_multi_row(renderer: &Value) -> Option<TrackInfo> {
         return None;
     }
 
-    // Show name = first subtitle run. The show name is reliably the
-    // first run for episodes; published date / other metadata live in
-    // their own dedicated fields (`publishedTimeText`, etc.).
-    let show_name = renderer["subtitle"]["runs"]
+    // YTM's podcast episode shape has TWO variants:
+    //
+    //   (A) older shape (matched by the existing tests):
+    //         subtitle.runs[0]      = show name
+    //         publishedTimeText     = publish-date display
+    //
+    //   (B) current live shape (verified Apr 2026 against
+    //         /tmp/vibeytm-resp-browse-*.json for BBC News etc.):
+    //         secondTitle.runs[0]   = show name (e.g. "BBC News")
+    //         subtitle.runs[0]      = publish-date display ("51 min ago")
+    //         (no publishedTimeText field)
+    //
+    // Detect by presence of `secondTitle.runs[0]`. When present, that's
+    // the show name and `subtitle` carries the publish date; when
+    // absent, fall back to the older shape.
+    let second_title_text = renderer["secondTitle"]["runs"]
         .as_array()
         .and_then(|runs| runs.first())
         .and_then(|r| r["text"].as_str())
-        .unwrap_or_default()
-        .to_string();
+        .filter(|s| !s.is_empty());
+    let subtitle_text = renderer["subtitle"]["runs"]
+        .as_array()
+        .and_then(|runs| runs.first())
+        .and_then(|r| r["text"].as_str())
+        .unwrap_or_default();
+    let show_name = second_title_text
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| subtitle_text.to_string());
 
     // VideoId — kaset reads `onTap.watchEndpoint.videoId` directly;
     // we keep the overlay fallback for resilience against shape drift.
@@ -3463,18 +3482,34 @@ fn parse_episode_from_multi_row(renderer: &Value) -> Option<TrackInfo> {
         Some(artwork_url)
     };
 
-    // Duration: kaset reads `data.durationText.runs[0].text` —
-    // flat, top-level on the renderer. The previous nested
-    // `playbackProgress.musicPlaybackProgressRenderer.durationText`
-    // path was wrong and always returned 0. Format may be
-    // "36 min" / "1 hr 30 min" (podcasts often) or "1:11:19" (some
-    // long-form episodes); both handled by parse_episode_duration_text.
-    let duration_text = renderer["durationText"]["runs"]
+    // Duration: try the top-level kaset path first ("36 min" / "1:11:19"),
+    // then fall back to the nested playbackProgress renderer used by the
+    // current live shape (where the duration sits in
+    // `playbackProgress.musicPlaybackProgressRenderer.durationText.runs[]`,
+    // typically as runs[" • ", "5 min"] — we scan all runs for the
+    // first parseable one rather than picking a fixed index).
+    let duration_text_top = renderer["durationText"]["runs"]
         .as_array()
         .and_then(|runs| runs.first())
         .and_then(|r| r["text"].as_str())
         .unwrap_or_default();
-    let duration_secs = parse_episode_duration_text(duration_text);
+    let mut duration_secs = parse_episode_duration_text(duration_text_top);
+    if duration_secs == 0.0 {
+        if let Some(runs) = renderer["playbackProgress"]
+            ["musicPlaybackProgressRenderer"]["durationText"]["runs"]
+            .as_array()
+        {
+            for run in runs {
+                if let Some(t) = run["text"].as_str() {
+                    let parsed = parse_episode_duration_text(t);
+                    if parsed > 0.0 {
+                        duration_secs = parsed;
+                        break;
+                    }
+                }
+            }
+        }
+    }
 
     // Description blurb — concatenate all runs so paragraph breaks /
     // multi-segment text comes through verbatim. Episodes that don't
@@ -3487,14 +3522,25 @@ fn parse_episode_from_multi_row(renderer: &Value) -> Option<TrackInfo> {
         Some(description)
     };
 
-    // Publish-date display string ("Mar 1, 2026" / "3 days ago").
-    // Take the first run only — YTM doesn't multi-segment this field.
+    // Publish-date display string ("Mar 1, 2026" / "51 min ago").
+    // Two paths to cover both shape variants:
+    //   (A) older: `publishedTimeText.runs[0].text`
+    //   (B) current live: `subtitle.runs[0].text` (only when
+    //       `secondTitle` carries the show name — otherwise subtitle
+    //       IS the show name and there's no publish date here).
     let published_at = renderer["publishedTimeText"]["runs"]
         .as_array()
         .and_then(|runs| runs.first())
         .and_then(|r| r["text"].as_str())
         .map(|s| s.to_string())
-        .filter(|s| !s.trim().is_empty());
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            if second_title_text.is_some() && !subtitle_text.trim().is_empty() {
+                Some(subtitle_text.to_string())
+            } else {
+                None
+            }
+        });
 
     Some(TrackInfo {
         video_id,
@@ -5783,6 +5829,40 @@ mod tests {
             Some("First half of the description. Second half — runs concatenate.")
         );
         assert_eq!(track.published_at.as_deref(), Some("Mar 1, 2026"));
+    }
+
+    #[test]
+    fn parse_episode_from_multi_row_handles_secondtitle_shape() {
+        // Live YTM shape (verified against
+        // /tmp/vibeytm-resp-browse-*.json on 2026-05-02):
+        //   secondTitle.runs[0]   = show name
+        //   subtitle.runs[0]      = publish-date display ("51 min ago")
+        //   playbackProgress.musicPlaybackProgressRenderer.durationText
+        //                         = duration runs (with " • " separators)
+        //   no publishedTimeText, no top-level durationText
+        let renderer = json!({
+            "title":      { "runs": [{ "text": "02/05/2026 21:01 GMT" }] },
+            "secondTitle": { "runs": [{ "text": "BBC News" }] },
+            "subtitle":   { "runs": [{ "text": "51 min ago" }] },
+            "description": { "runs": [{ "text": "The latest five minute news bulletin." }] },
+            "playbackProgress": {
+                "musicPlaybackProgressRenderer": {
+                    "durationText": { "runs": [
+                        { "text": " • " },
+                        { "text": "5 min" }
+                    ] }
+                }
+            },
+            "onTap": { "watchEndpoint": { "videoId": "epLive1" } }
+        });
+        let track = super::parse_episode_from_multi_row(&renderer)
+            .expect("renderer should parse");
+        // Show name comes from secondTitle, NOT subtitle
+        assert_eq!(track.artist, "BBC News");
+        // Subtitle becomes the publish-date display
+        assert_eq!(track.published_at.as_deref(), Some("51 min ago"));
+        // Duration parsed from the nested playbackProgress shape
+        assert_eq!(track.duration_secs, 300.0);
     }
 
     #[test]

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -269,7 +269,7 @@ impl YtmApi {
     /// playlist-shelf-of-tracks structure as the liked-videos endpoint.
     /// Replaces the locally-tracked playback log added in #83 — the
     /// follow-up issue requested matching YTM's authoritative history.
-    pub async fn get_history(&self, app: &AppHandle) -> anyhow::Result<Vec<TrackInfo>> {
+    pub async fn get_history(&self, app: &AppHandle) -> anyhow::Result<Vec<HistorySection>> {
         let body = serde_json::json!({ "browseId": "FEmusic_history" }).to_string();
         // Short TTL — the user's expectation is that "recently played"
         // reflects the latest plays, so we don't want a stale 5-min
@@ -283,7 +283,7 @@ impl YtmApi {
         .await
         .map_err(anyhow::Error::msg)?;
         let data: Value = serde_json::from_str(&raw)?;
-        Ok(parse_library_songs(&data))
+        Ok(parse_history_grouped(&data))
     }
 
     /// Fetch user's liked/library songs via the real YTM API.
@@ -2104,6 +2104,81 @@ fn parse_library_songs(data: &Value) -> Vec<TrackInfo> {
         }
     }
     tracks
+}
+
+/// Walk the FEmusic_history `sectionListRenderer` and emit one
+/// `HistorySection` per date-grouped carousel/shelf, preserving the
+/// header label YTM uses ("Today", "Yesterday", a specific date, etc.)
+/// so the FE can bucket entries into Today / Yesterday / This week /
+/// Earlier without inventing its own date logic.
+fn parse_history_grouped(data: &Value) -> Vec<HistorySection> {
+    let paths = [
+        &data["contents"]["singleColumnBrowseResultsRenderer"]["tabs"][0]["tabRenderer"]
+            ["content"]["sectionListRenderer"]["contents"],
+        &data["contents"]["twoColumnBrowseResultsRenderer"]["secondaryContents"]
+            ["sectionListRenderer"]["contents"],
+    ];
+
+    let mut out: Vec<HistorySection> = Vec::new();
+    for path in paths {
+        let Some(sections) = path.as_array() else { continue };
+        for section in sections {
+            collect_history_section(section, &mut out);
+            // Library responses sometimes wrap the date shelves inside
+            // an itemSectionRenderer — dig one level deeper to be safe.
+            if let Some(inner) = section["itemSectionRenderer"]["contents"].as_array() {
+                for inner_item in inner {
+                    collect_history_section(inner_item, &mut out);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn collect_history_section(section: &Value, out: &mut Vec<HistorySection>) {
+    // Carousel-style date shelves (the common shape on FEmusic_history).
+    if let Some(carousel) = section.get("musicCarouselShelfRenderer") {
+        if let Some(s) = build_history_section_from_renderer(
+            &carousel["header"]["musicCarouselShelfBasicHeaderRenderer"]["title"]["runs"],
+            &carousel["contents"],
+        ) {
+            out.push(s);
+        }
+    }
+    // Plain shelf shape — kept as a defensive fallback in case YTM ever
+    // swaps the carousel for a flat list within the history endpoint.
+    if let Some(shelf) = section.get("musicShelfRenderer") {
+        if let Some(s) = build_history_section_from_renderer(
+            &shelf["title"]["runs"],
+            &shelf["contents"],
+        ) {
+            out.push(s);
+        }
+    }
+}
+
+fn build_history_section_from_renderer(
+    title_runs: &Value,
+    contents: &Value,
+) -> Option<HistorySection> {
+    let label = runs_text(title_runs);
+    if label.is_empty() {
+        return None;
+    }
+    let items = contents.as_array()?;
+    let mut tracks = Vec::new();
+    for item in items {
+        if let Some(renderer) = item.get("musicResponsiveListItemRenderer") {
+            if let Some(track) = parse_track_from_list_item(renderer) {
+                tracks.push(track);
+            }
+        }
+    }
+    if tracks.is_empty() {
+        return None;
+    }
+    Some(HistorySection { label, tracks })
 }
 
 fn parse_library_albums(data: &Value) -> Vec<AlbumSummary> {
@@ -5655,6 +5730,118 @@ mod tests {
         assert_eq!(tracks.len(), 1, "expected 1 track from carousel shelf");
         assert_eq!(tracks[0].title, "Recently Played Song");
         assert_eq!(tracks[0].video_id, "histVid1");
+    }
+
+    #[test]
+    fn parse_history_grouped_keeps_section_labels() {
+        // FEmusic_history wraps date-grouped tracks inside
+        // `musicCarouselShelfRenderer` sections whose header carries the
+        // user-facing label ("Today", "Yesterday", a date string, ...).
+        // parse_history_grouped must preserve those labels so the FE
+        // can bucket entries.
+        let make_section = |label: &str, video_id: &str, title: &str| {
+            json!({
+                "musicCarouselShelfRenderer": {
+                    "header": {
+                        "musicCarouselShelfBasicHeaderRenderer": {
+                            "title": { "runs": [{ "text": label }] }
+                        }
+                    },
+                    "contents": [
+                        {
+                            "musicResponsiveListItemRenderer": {
+                                "flexColumns": [
+                                    {
+                                        "musicResponsiveListItemFlexColumnRenderer": {
+                                            "text": { "runs": [{
+                                                "text": title,
+                                                "navigationEndpoint": {
+                                                    "watchEndpoint": { "videoId": video_id }
+                                                }
+                                            }] }
+                                        }
+                                    },
+                                    {
+                                        "musicResponsiveListItemFlexColumnRenderer": {
+                                            "text": { "runs": [{ "text": "Some Artist" }] }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            })
+        };
+        let data = json!({
+            "contents": {
+                "singleColumnBrowseResultsRenderer": {
+                    "tabs": [{
+                        "tabRenderer": {
+                            "content": {
+                                "sectionListRenderer": {
+                                    "contents": [
+                                        make_section("Today", "vidToday", "Track A"),
+                                        make_section("Yesterday", "vidY", "Track B"),
+                                        make_section("Last week", "vidLW", "Track C")
+                                    ]
+                                }
+                            }
+                        }
+                    }]
+                }
+            }
+        });
+        let sections = super::parse_history_grouped(&data);
+        assert_eq!(sections.len(), 3, "expected 3 grouped sections");
+        assert_eq!(sections[0].label, "Today");
+        assert_eq!(sections[0].tracks.len(), 1);
+        assert_eq!(sections[0].tracks[0].title, "Track A");
+        assert_eq!(sections[1].label, "Yesterday");
+        assert_eq!(sections[2].label, "Last week");
+    }
+
+    #[test]
+    fn parse_history_grouped_skips_sections_with_no_tracks_or_no_label() {
+        // Sections without a header label OR with no parsed tracks are
+        // dropped — they'd render as ghost group headers in the FE.
+        let data = json!({
+            "contents": {
+                "singleColumnBrowseResultsRenderer": {
+                    "tabs": [{
+                        "tabRenderer": {
+                            "content": {
+                                "sectionListRenderer": {
+                                    "contents": [
+                                        // missing header
+                                        {
+                                            "musicCarouselShelfRenderer": {
+                                                "contents": [
+                                                    { "musicResponsiveListItemRenderer": {} }
+                                                ]
+                                            }
+                                        },
+                                        // header but empty contents
+                                        {
+                                            "musicCarouselShelfRenderer": {
+                                                "header": {
+                                                    "musicCarouselShelfBasicHeaderRenderer": {
+                                                        "title": { "runs": [{ "text": "Today" }] }
+                                                    }
+                                                },
+                                                "contents": []
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }]
+                }
+            }
+        });
+        let sections = super::parse_history_grouped(&data);
+        assert!(sections.is_empty(), "expected both malformed sections to drop");
     }
 
     #[test]

--- a/src-tauri/src/ytm_api/mod.rs
+++ b/src-tauri/src/ytm_api/mod.rs
@@ -3382,6 +3382,7 @@ fn parse_track_from_list_item(renderer: &Value) -> Option<TrackInfo> {
         album_id: None,
         artwork_url,
         duration_secs,
+        ..Default::default()
     })
 }
 
@@ -3475,6 +3476,26 @@ fn parse_episode_from_multi_row(renderer: &Value) -> Option<TrackInfo> {
         .unwrap_or_default();
     let duration_secs = parse_episode_duration_text(duration_text);
 
+    // Description blurb — concatenate all runs so paragraph breaks /
+    // multi-segment text comes through verbatim. Episodes that don't
+    // expose a description leave the field as None so the FE renders
+    // nothing rather than an empty line.
+    let description = runs_text(&renderer["description"]["runs"]);
+    let description = if description.trim().is_empty() {
+        None
+    } else {
+        Some(description)
+    };
+
+    // Publish-date display string ("Mar 1, 2026" / "3 days ago").
+    // Take the first run only — YTM doesn't multi-segment this field.
+    let published_at = renderer["publishedTimeText"]["runs"]
+        .as_array()
+        .and_then(|runs| runs.first())
+        .and_then(|r| r["text"].as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.trim().is_empty());
+
     Some(TrackInfo {
         video_id,
         title,
@@ -3484,6 +3505,8 @@ fn parse_episode_from_multi_row(renderer: &Value) -> Option<TrackInfo> {
         album_id: None,
         artwork_url,
         duration_secs,
+        description,
+        published_at,
     })
 }
 
@@ -3580,6 +3603,7 @@ fn parse_track_from_two_row(two_row: &Value) -> Option<TrackInfo> {
         album_id: None,
         artwork_url,
         duration_secs: 0.0,
+        ..Default::default()
     })
 }
 
@@ -4105,6 +4129,7 @@ fn extract_upcoming_tracks(data: &Value, current_video_id: &str, limit: usize) -
             album_id: None,
             artwork_url,
             duration_secs,
+            ..Default::default()
         });
     }
     out
@@ -5730,6 +5755,48 @@ mod tests {
         assert_eq!(tracks.len(), 1, "expected 1 track from carousel shelf");
         assert_eq!(tracks[0].title, "Recently Played Song");
         assert_eq!(tracks[0].video_id, "histVid1");
+    }
+
+    #[test]
+    fn parse_episode_from_multi_row_extracts_description_and_published_at() {
+        // Podcast episodes carry `description.runs` and
+        // `publishedTimeText.runs` alongside the standard track fields.
+        // The episode parser must surface them so the FE can render
+        // per-episode details on the show detail page.
+        let renderer = json!({
+            "title": { "runs": [{ "text": "Ep 42: Deep dive" }] },
+            "subtitle": { "runs": [{ "text": "The Show" }] },
+            "description": { "runs": [
+                { "text": "First half of the description. " },
+                { "text": "Second half — runs concatenate." }
+            ] },
+            "publishedTimeText": { "runs": [{ "text": "Mar 1, 2026" }] },
+            "durationText": { "runs": [{ "text": "36 min" }] },
+            "onTap": { "watchEndpoint": { "videoId": "epVid42" } }
+        });
+        let track = super::parse_episode_from_multi_row(&renderer)
+            .expect("renderer should parse");
+        assert_eq!(track.title, "Ep 42: Deep dive");
+        assert_eq!(track.video_id, "epVid42");
+        assert_eq!(
+            track.description.as_deref(),
+            Some("First half of the description. Second half — runs concatenate.")
+        );
+        assert_eq!(track.published_at.as_deref(), Some("Mar 1, 2026"));
+    }
+
+    #[test]
+    fn parse_episode_from_multi_row_leaves_optional_fields_none_when_absent() {
+        let renderer = json!({
+            "title": { "runs": [{ "text": "Untitled" }] },
+            "subtitle": { "runs": [{ "text": "Show" }] },
+            "durationText": { "runs": [{ "text": "10 min" }] },
+            "onTap": { "watchEndpoint": { "videoId": "vid1" } }
+        });
+        let track = super::parse_episode_from_multi_row(&renderer)
+            .expect("renderer should parse");
+        assert!(track.description.is_none(), "no description in input");
+        assert!(track.published_at.is_none(), "no publishedTimeText in input");
     }
 
     #[test]

--- a/src-tauri/src/ytm_api/types.rs
+++ b/src-tauri/src/ytm_api/types.rs
@@ -95,6 +95,18 @@ pub struct PodcastLastEpisode {
     pub secs_ago: Option<i64>,
 }
 
+/// One date-grouped section of the FEmusic_history response. YTM groups
+/// recently-played tracks under headers like "Today", "Yesterday",
+/// "Last week", or specific calendar dates. Preserving the section
+/// label lets the FE bucket entries into Today / Yesterday / This week
+/// / Earlier without inventing its own date-grouping logic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistorySection {
+    pub label: String,
+    pub tracks: Vec<TrackInfo>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Shelf {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.34",
+  "version": "1.2.0",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/DetailPageHero.tsx
+++ b/src/components/DetailPageHero.tsx
@@ -1,4 +1,12 @@
-import { type FC, type ReactNode, useMemo } from 'react';
+import {
+  type FC,
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import type { CoverColors } from '../lib/coverColors';
 import { CachedImage } from './CachedImage';
@@ -125,6 +133,9 @@ export const DetailPageHero: FC<DetailPageHeroProps> = ({
           type="button"
           onClick={onBack}
           aria-label="Back"
+          // Marker for the global CSS rule that hides this button while
+          // the Now Playing overlay is open (see styles/global.css).
+          data-detail-back-button=""
           style={{
             // Portaled to document.body so the button shares the body
             // stacking context with the title-bar drag region (z 200)
@@ -251,23 +262,7 @@ export const DetailPageHero: FC<DetailPageHeroProps> = ({
               {meta}
             </div>
           )}
-          {description && (
-            <p
-              style={{
-                fontSize: 'var(--text-sm)',
-                color: 'var(--color-text-tertiary)',
-                margin: 0,
-                lineHeight: 1.5,
-                maxWidth: '500px',
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-              }}
-            >
-              {description}
-            </p>
-          )}
+          {description && <ExpandableDescription text={description} />}
           <div
             style={{
               display: 'flex',
@@ -383,3 +378,87 @@ function withAlpha(color: string, alpha: number): string {
   const pct = Math.round(alpha * 100);
   return `color-mix(in oklab, ${color} ${pct}%, transparent)`;
 }
+
+/**
+ * Description blurb with a "More" / "Less" toggle that appears only
+ * when the text actually overflows the 2-line clamp. Long podcast
+ * descriptions stay collapsed by default; users opt in to the full
+ * text on demand. Pure presentational; no portals or globals.
+ */
+const COLLAPSED_LINE_CLAMP = 2;
+
+const ExpandableDescription: FC<{ text: string }> = ({ text }) => {
+  const ref = useRef<HTMLParagraphElement | null>(null);
+  // `null` until we've measured at least once. Drives whether the
+  // toggle button renders (we only show it when the text genuinely
+  // overflows the clamp).
+  const [isOverflowing, setIsOverflowing] = useState<boolean | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Re-measure whenever the text changes OR on resize, since the
+  // clamp's overflow status depends on the container width.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [text]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const obs = new ResizeObserver(() => {
+      // While expanded the clamp is off, so scrollHeight === clientHeight
+      // and we'd flip overflow off mid-flight. Skip while expanded;
+      // re-evaluate the next time the user collapses.
+      if (isExpanded) return;
+      setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [isExpanded]);
+
+  const clampStyle =
+    isExpanded
+      ? {}
+      : {
+          display: '-webkit-box',
+          WebkitLineClamp: COLLAPSED_LINE_CLAMP,
+          WebkitBoxOrient: 'vertical' as const,
+          overflow: 'hidden',
+        };
+
+  return (
+    <div style={{ maxWidth: '500px' }}>
+      <p
+        ref={ref}
+        style={{
+          fontSize: 'var(--text-sm)',
+          color: 'var(--color-text-tertiary)',
+          margin: 0,
+          lineHeight: 1.5,
+          ...clampStyle,
+        }}
+      >
+        {text}
+      </p>
+      {(isOverflowing || isExpanded) && (
+        <button
+          type="button"
+          onClick={() => setIsExpanded((v) => !v)}
+          style={{
+            marginTop: 'var(--space-1)',
+            padding: 0,
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--color-accent)',
+            fontSize: 'var(--text-sm)',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {isExpanded ? 'Less' : 'More'}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/browse/EpisodeRow.test.tsx
+++ b/src/components/browse/EpisodeRow.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { TrackInfo } from '../../lib/types';
+
+vi.mock('../../lib/ipc', () => ({
+  playerApi: { playTrack: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('../CachedImage', () => ({
+  CachedImage: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+vi.mock('../contextMenu/ContextMenu', () => ({
+  ContextMenuTarget: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../contextMenu/trackActions', () => ({
+  buildTrackContextMenu: () => [],
+}));
+
+const { EpisodeRow } = await import('./EpisodeRow');
+
+const episode = (overrides: Partial<TrackInfo> = {}): TrackInfo => ({
+  videoId: 'ep1',
+  title: 'Some Episode Title',
+  artist: 'The Show',
+  album: '',
+  durationSecs: 36 * 60,
+  publishedAt: 'Mar 1, 2026',
+  description: 'A blurb about the episode.',
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('EpisodeRow', () => {
+  it('renders title, formatted duration, publish date, and description', () => {
+    render(<EpisodeRow track={episode()} />);
+    expect(screen.getByText('Some Episode Title')).toBeInTheDocument();
+    // Meta line concatenates publish-date and long-form duration.
+    expect(screen.getByText(/Mar 1, 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/36 min/)).toBeInTheDocument();
+    expect(screen.getByText('A blurb about the episode.')).toBeInTheDocument();
+  });
+
+  it('formats hour-plus durations as "X hr Y min"', () => {
+    render(
+      <EpisodeRow track={episode({ durationSecs: 90 * 60, publishedAt: undefined })} />,
+    );
+    expect(screen.getByText(/1 hr 30 min/)).toBeInTheDocument();
+  });
+
+  it('drops "0 min" suffix for whole-hour durations', () => {
+    render(
+      <EpisodeRow track={episode({ durationSecs: 60 * 60, publishedAt: undefined })} />,
+    );
+    const meta = screen.getByText(/1 hr/);
+    expect(meta.textContent).not.toMatch(/0 min/);
+  });
+
+  it('omits the meta line entirely when no publish date and no duration', () => {
+    render(
+      <EpisodeRow
+        track={episode({ durationSecs: 0, publishedAt: undefined, description: undefined })}
+      />,
+    );
+    // Title still renders; meta paragraph (uppercase eyebrow) does not.
+    expect(screen.getByText('Some Episode Title')).toBeInTheDocument();
+    expect(screen.queryByText(/Mar 1, 2026/)).toBeNull();
+  });
+
+  it('omits the description paragraph when description is missing', () => {
+    render(<EpisodeRow track={episode({ description: undefined })} />);
+    expect(screen.queryByText('A blurb about the episode.')).toBeNull();
+  });
+});

--- a/src/components/browse/EpisodeRow.tsx
+++ b/src/components/browse/EpisodeRow.tsx
@@ -107,19 +107,6 @@ export const EpisodeRow: FC<EpisodeRowProps> = ({ track, playlistId }) => {
             gap: 'var(--space-1)',
           }}
         >
-          {metaParts.length > 0 && (
-            <div
-              style={{
-                fontSize: 'var(--text-xs)',
-                fontWeight: 600,
-                color: 'var(--color-text-tertiary)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.06em',
-              }}
-            >
-              {metaParts.join(' · ')}
-            </div>
-          )}
           <div
             style={{
               fontSize: 'var(--text-base)',
@@ -136,6 +123,17 @@ export const EpisodeRow: FC<EpisodeRowProps> = ({ track, playlistId }) => {
           >
             {track.title}
           </div>
+          {metaParts.length > 0 && (
+            <div
+              style={{
+                fontSize: 'var(--text-xs)',
+                color: 'var(--color-text-tertiary)',
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {metaParts.join(' · ')}
+            </div>
+          )}
           {track.description && (
             <p
               style={{

--- a/src/components/browse/EpisodeRow.tsx
+++ b/src/components/browse/EpisodeRow.tsx
@@ -1,6 +1,7 @@
 import { type FC, useState } from 'react';
 import type { TrackInfo } from '../../lib/types';
 import { playerApi } from '../../lib/ipc';
+import { debug } from '../../lib/debug';
 import { CachedImage } from '../CachedImage';
 import { ContextMenuTarget } from '../contextMenu/ContextMenu';
 import { buildTrackContextMenu } from '../contextMenu/trackActions';
@@ -44,7 +45,12 @@ export const EpisodeRow: FC<EpisodeRowProps> = ({ track, playlistId }) => {
 
   const handleClick = () => {
     if (track.videoId) {
-      playerApi.playTrack(track.videoId, playlistId).catch(() => {});
+      playerApi.playTrack(track.videoId, playlistId).catch((e) => {
+        debug.error('EpisodeRow', 'playTrack failed', {
+          videoId: track.videoId,
+          error: String(e),
+        });
+      });
     }
   };
 

--- a/src/components/browse/EpisodeRow.tsx
+++ b/src/components/browse/EpisodeRow.tsx
@@ -1,0 +1,159 @@
+import { type FC, useState } from 'react';
+import type { TrackInfo } from '../../lib/types';
+import { playerApi } from '../../lib/ipc';
+import { CachedImage } from '../CachedImage';
+import { ContextMenuTarget } from '../contextMenu/ContextMenu';
+import { buildTrackContextMenu } from '../contextMenu/trackActions';
+
+interface EpisodeRowProps {
+  /** The episode's TrackInfo. Reads `description` and `publishedAt`
+   *  alongside the standard fields when present. */
+  track: TrackInfo;
+  /** Show / podcast playlistId. Drives the playback context. */
+  playlistId?: string;
+}
+
+/**
+ * Format an episode's duration in long-form ("36 min", "1 hr 30 min")
+ * to match the YTM web layout for podcasts. Falls back to MM:SS for
+ * sub-minute clips.
+ */
+const formatEpisodeDuration = (secs: number): string => {
+  if (secs <= 0) return '';
+  const totalMinutes = Math.floor(secs / 60);
+  if (totalMinutes < 1) return `${Math.floor(secs)} sec`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) {
+    return minutes === 0 ? `${hours} hr` : `${hours} hr ${minutes} min`;
+  }
+  return `${minutes} min`;
+};
+
+/**
+ * Detail-rich row for a single podcast / show episode. Larger cover,
+ * publish-date eyebrow above the title, full duration, and a 3-line
+ * description preview underneath. Clicking the row plays the episode.
+ *
+ * Mirrors SongRow's playback + context-menu behavior so users get the
+ * same affordances they have for music tracks; only the visual layout
+ * is enriched with the episode-specific metadata.
+ */
+export const EpisodeRow: FC<EpisodeRowProps> = ({ track, playlistId }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleClick = () => {
+    if (track.videoId) {
+      playerApi.playTrack(track.videoId, playlistId).catch(() => {});
+    }
+  };
+
+  const durationLabel = formatEpisodeDuration(track.durationSecs);
+  const metaParts: string[] = [];
+  if (track.publishedAt) metaParts.push(track.publishedAt);
+  if (durationLabel) metaParts.push(durationLabel);
+
+  return (
+    <ContextMenuTarget buildSections={() => buildTrackContextMenu({ track })}>
+      <button
+        onClick={handleClick}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 'var(--space-4)',
+          width: '100%',
+          padding: 'var(--space-3) var(--space-3) var(--space-3) 0',
+          background: isHovered ? 'var(--color-surface-2)' : 'transparent',
+          border: 'none',
+          borderRadius: 'var(--radius-md)',
+          cursor: 'pointer',
+          textAlign: 'left',
+          transition: 'background var(--duration-fast) var(--ease-out)',
+        }}
+      >
+        <div
+          style={{
+            width: 80,
+            height: 80,
+            borderRadius: 'var(--radius-md)',
+            overflow: 'hidden',
+            background: 'var(--color-surface-3)',
+            flexShrink: 0,
+          }}
+        >
+          {track.artworkUrl && (
+            <CachedImage
+              src={track.artworkUrl}
+              alt={`${track.title} artwork`}
+              loading="lazy"
+              width={80}
+              height={80}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
+            />
+          )}
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-1)',
+          }}
+        >
+          {metaParts.length > 0 && (
+            <div
+              style={{
+                fontSize: 'var(--text-xs)',
+                fontWeight: 600,
+                color: 'var(--color-text-tertiary)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+              }}
+            >
+              {metaParts.join(' · ')}
+            </div>
+          )}
+          <div
+            style={{
+              fontSize: 'var(--text-base)',
+              fontWeight: 600,
+              color: 'var(--color-text-primary)',
+              lineHeight: 1.3,
+              // Two-line clamp on the title so very long episode names
+              // don't push the description out of the row's height.
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {track.title}
+          </div>
+          {track.description && (
+            <p
+              style={{
+                fontSize: 'var(--text-sm)',
+                color: 'var(--color-text-secondary)',
+                margin: 0,
+                lineHeight: 1.5,
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {track.description}
+            </p>
+          )}
+        </div>
+      </button>
+    </ContextMenuTarget>
+  );
+};

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   PodcastsIcon,
   SearchIcon,
   SettingsIcon,
-  SongsIcon,
 } from '../icons';
 
 interface NavItemProps {
@@ -128,7 +127,6 @@ const NAV_ITEMS: { path: string; label: string; icon: ReactNode }[] = [
 // puts "Recently Played" in the same section as the user's library.
 const LIBRARY_ITEMS: { path: string; label: string; icon: ReactNode }[] = [
   { path: 'library/playlists', label: 'Playlists', icon: <PlaylistsIcon size={16} /> },
-  { path: 'library/songs', label: 'Songs', icon: <SongsIcon size={16} /> },
   { path: 'library/albums', label: 'Albums', icon: <AlbumsIcon size={16} /> },
   { path: 'library/artists', label: 'Artists', icon: <ArtistsIcon size={16} /> },
   { path: 'library/podcasts', label: 'Podcasts', icon: <PodcastsIcon size={16} /> },

--- a/src/components/overlay/SafeOverlay.test.tsx
+++ b/src/components/overlay/SafeOverlay.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
 import { SafeOverlay, useOverlayOpen } from './SafeOverlay';
 
 // SafeOverlay locks down the four WKWebView click-loss invariants the
@@ -186,6 +186,113 @@ describe('SafeOverlay', () => {
     );
     expect(observedOpen).toBe(true);
     expect(observedClosed).toBe(false);
+  });
+
+  describe('willChange lifecycle (issue #99 — stacked-blur flicker)', () => {
+    // The wrapper's `will-change` is gated on a `transitioning` flag
+    // that flips true on every isOpen change and back to false 480 ms
+    // later. A permanent `will-change: opacity, transform` keeps
+    // WKWebView's GPU layer for the overlay promoted forever; when
+    // two SafeOverlays both with backdrop-filter stack in the same
+    // screen region (NowPlaying + a drawer), that triggers a paint
+    // feedback loop. Demoting after the transition settles breaks the
+    // loop. These tests pin that lifecycle so a future edit can't
+    // silently regress the fix.
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('promotes will-change while transitioning, demotes after settle', () => {
+      render(
+        <SafeOverlay isOpen ariaLabel="test">
+          <div>content</div>
+        </SafeOverlay>,
+      );
+      const wrapper = screen.getByLabelText('test');
+      // Mount kicks the effect synchronously — wrapper is in the
+      // transitioning state.
+      expect(wrapper.style.willChange).toBe('opacity, transform');
+
+      // Just under the 480 ms settle: still transitioning.
+      act(() => {
+        vi.advanceTimersByTime(479);
+      });
+      expect(wrapper.style.willChange).toBe('opacity, transform');
+
+      // Past the settle: layer demotes.
+      act(() => {
+        vi.advanceTimersByTime(2);
+      });
+      expect(wrapper.style.willChange).toBe('auto');
+    });
+
+    it('flipping isOpen re-promotes will-change for the next animation', () => {
+      const { rerender } = render(
+        <SafeOverlay isOpen ariaLabel="test">
+          <div>content</div>
+        </SafeOverlay>,
+      );
+      const wrapper = screen.getByLabelText('test');
+
+      // Settle the initial mount transition.
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(wrapper.style.willChange).toBe('auto');
+
+      // Close — the close transition needs willChange promoted again.
+      rerender(
+        <SafeOverlay isOpen={false} ariaLabel="test">
+          <div>content</div>
+        </SafeOverlay>,
+      );
+      expect(wrapper.style.willChange).toBe('opacity, transform');
+
+      // Settle again.
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(wrapper.style.willChange).toBe('auto');
+    });
+
+    it('rapid isOpen flips cancel the prior demote timer (no premature demote)', () => {
+      const { rerender } = render(
+        <SafeOverlay isOpen ariaLabel="test">
+          <div>content</div>
+        </SafeOverlay>,
+      );
+      const wrapper = screen.getByLabelText('test');
+      expect(wrapper.style.willChange).toBe('opacity, transform');
+
+      // Flip just before the prior timer would have fired.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      rerender(
+        <SafeOverlay isOpen={false} ariaLabel="test">
+          <div>content</div>
+        </SafeOverlay>,
+      );
+      // The prior 480 ms timer must have been cancelled by the effect
+      // cleanup; advancing past its original deadline must NOT demote.
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      // 500 ms total elapsed since mount — without cleanup, the first
+      // timer would have fired at 480 ms and demoted. The fresh
+      // transition started at 300 ms; it has 480 ms ahead of it.
+      expect(wrapper.style.willChange).toBe('opacity, transform');
+
+      // Settle the second transition.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(wrapper.style.willChange).toBe('auto');
+    });
   });
 
   it('passes inset overrides to the wrapper position', () => {

--- a/src/components/overlay/SafeOverlay.tsx
+++ b/src/components/overlay/SafeOverlay.tsx
@@ -5,6 +5,8 @@ import {
   createContext,
   forwardRef,
   useContext,
+  useEffect,
+  useState,
 } from 'react';
 
 /**
@@ -130,6 +132,23 @@ export const SafeOverlay = forwardRef<HTMLElement, SafeOverlayProps>(function Sa
   const right = inset?.right ?? DEFAULT_INSET.right;
   const bottom = inset?.bottom ?? DEFAULT_INSET.bottom;
 
+  // Permanent `willChange: 'opacity, transform'` keeps WKWebView's GPU
+  // layer for this overlay promoted forever — fine on its own, but when
+  // two SafeOverlays both with `backdrop-filter` stack in the same
+  // screen region (e.g. NowPlaying + LyricsOverlay or NowPlaying +
+  // QueuePanel), WKWebView enters a paint feedback loop and the user
+  // sees continuous flicker (issue #99). Demote the layer to `auto`
+  // once the entrance/exit transition completes so the GPU stops
+  // re-rasterising it every frame.
+  const [transitioning, setTransitioning] = useState(false);
+  useEffect(() => {
+    setTransitioning(true);
+    // Match the 420 ms transition duration below; small slack so the
+    // demote happens after the last animation frame.
+    const handle = setTimeout(() => setTransitioning(false), 480);
+    return () => clearTimeout(handle);
+  }, [isOpen]);
+
   // Back-compat: an explicit `rise={false}` disables the entrance entirely
   // (transform stays `none`). New callers should use `slideFrom`.
   const effectiveSlide: SlideDirection | 'none' =
@@ -194,7 +213,10 @@ export const SafeOverlay = forwardRef<HTMLElement, SafeOverlayProps>(function Sa
     // (WKWebView hit-test bug, see SafeOverlay.test.tsx contracts).
     transform,
     pointerEvents: isOpen ? 'auto' : 'none',
-    willChange: 'opacity, transform',
+    // Only hint willChange while the overlay is animating. Permanent
+    // GPU promotion stacks badly with backdrop-filter layers in
+    // WKWebView (issue #99).
+    willChange: transitioning ? 'opacity, transform' : 'auto',
     // Opacity and transform share the same 420 ms cubic-bezier so the
     // closing motion plays at exactly the same speed as the opening
     // motion. Previously opacity used the shorter `--duration-normal`

--- a/src/components/pages/ArtistPage.tsx
+++ b/src/components/pages/ArtistPage.tsx
@@ -166,8 +166,8 @@ export const ArtistPage: FC<ArtistPageProps> = ({
           zIndex: 10,
           flexShrink: 0,
           background: 'transparent',
-          backdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
-          WebkitBackdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
+          backdropFilter: 'var(--page-sticky-blur)',
+          WebkitBackdropFilter: 'var(--page-sticky-blur)',
         }}
       >
         <DetailPageHero

--- a/src/components/pages/HistoryPage.test.tsx
+++ b/src/components/pages/HistoryPage.test.tsx
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import type { TrackInfo } from '../../lib/types';
+import type { HistorySection, TrackInfo } from '../../lib/types';
 
-// Issue #93 — HistoryPage now fetches from YTM's `FEmusic_history`
-// via `browseApi.getHistory`. These tests pin the four states the
-// page renders: loading skeletons, error message, empty state, and
-// populated list. Mocks the IPC + the SongRow row component so the
-// tests stay component-scoped.
+// HistoryPage now fetches date-grouped sections from
+// `browseApi.getHistory` and buckets them on the FE into Today /
+// Yesterday / This week / Earlier. These tests pin the four states
+// the page renders (loading, populated grouped, empty, error) plus
+// the bucketing helper itself.
 
 const getHistoryMock = vi.fn();
 const rememberMock = vi.fn();
@@ -32,7 +32,12 @@ vi.mock('../Skeleton', () => ({
   SkeletonCard: () => null,
 }));
 
-const { HistoryPage } = await import('./HistoryPage');
+// LiquidGlass is heavy + DOM-effect-driven; stub to a passthrough.
+vi.mock('@liquidglass/react', () => ({
+  LiquidGlass: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const { HistoryPage, bucketHistorySections } = await import('./HistoryPage');
 
 const track = (id: string, title: string): TrackInfo => ({
   videoId: id,
@@ -40,6 +45,11 @@ const track = (id: string, title: string): TrackInfo => ({
   artist: 'Artist',
   album: 'Album',
   durationSecs: 180,
+});
+
+const section = (label: string, tracks: TrackInfo[]): HistorySection => ({
+  label,
+  tracks,
 });
 
 beforeEach(() => {
@@ -51,24 +61,37 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('HistoryPage — YTM-backed history (issue #93)', () => {
+describe('HistoryPage — grouped history', () => {
   it('renders skeleton rows while the IPC is in flight', () => {
-    // Promise that never resolves so we observe the loading state.
     getHistoryMock.mockReturnValue(new Promise(() => {}));
     render(<HistoryPage />);
     expect(screen.getAllByTestId('skeleton-row').length).toBeGreaterThan(0);
   });
 
-  it('renders the populated list when getHistory resolves with tracks', async () => {
+  it('renders bucket headings and tracks under each', async () => {
     getHistoryMock.mockResolvedValue([
-      track('a', 'Track A'),
-      track('b', 'Track B'),
+      section('Today', [track('t1', 'Today Song')]),
+      section('Yesterday', [track('y1', 'Yesterday Song')]),
+      section('Last week', [track('lw1', 'Older Song')]),
     ]);
     render(<HistoryPage />);
-    await waitFor(() => {
-      expect(screen.getByText('Track A')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Track B')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('Today Song')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Yesterday Song')).toBeInTheDocument();
+    expect(screen.getByText('Older Song')).toBeInTheDocument();
+    // Group headings rendered for non-empty buckets only — "Today",
+    // "Yesterday", and "Earlier" (Last week is bucketed there because
+    // its date can't be parsed).
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Today' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Yesterday' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Earlier' }),
+    ).toBeInTheDocument();
     expect(rememberMock).toHaveBeenCalled();
     expect(screen.queryByTestId('skeleton-row')).toBeNull();
   });
@@ -90,5 +113,82 @@ describe('HistoryPage — YTM-backed history (issue #93)', () => {
     await waitFor(() =>
       expect(screen.getByText(/Could not load history/i)).toBeInTheDocument(),
     );
+  });
+});
+
+describe('bucketHistorySections', () => {
+  // Pin a fixed "now" so the date math is deterministic.
+  const now = new Date('2026-05-02T10:00:00Z');
+
+  it('routes "Today" and "Yesterday" labels into their named buckets', () => {
+    const out = bucketHistorySections(
+      [
+        section('Today', [track('a', 'A')]),
+        section('Yesterday', [track('b', 'B')]),
+      ],
+      now,
+    );
+    expect(out.Today.map((t) => t.title)).toEqual(['A']);
+    expect(out.Yesterday.map((t) => t.title)).toEqual(['B']);
+    expect(out['This week']).toEqual([]);
+    expect(out.Earlier).toEqual([]);
+  });
+
+  it('case-insensitive on the day labels', () => {
+    const out = bucketHistorySections(
+      [
+        section('TODAY', [track('a', 'A')]),
+        section('  yesterday  ', [track('b', 'B')]),
+      ],
+      now,
+    );
+    expect(out.Today.map((t) => t.title)).toEqual(['A']);
+    expect(out.Yesterday.map((t) => t.title)).toEqual(['B']);
+  });
+
+  it('dates within the last 6 days (excluding today/yesterday) go to "This week"', () => {
+    // 3 days before "now": 2026-04-29
+    const out = bucketHistorySections(
+      [section('April 29, 2026', [track('a', 'A')])],
+      now,
+    );
+    expect(out['This week'].map((t) => t.title)).toEqual(['A']);
+    expect(out.Earlier).toEqual([]);
+  });
+
+  it('older parsed dates fall to "Earlier"', () => {
+    const out = bucketHistorySections(
+      [section('March 1, 2026', [track('a', 'A')])],
+      now,
+    );
+    expect(out.Earlier.map((t) => t.title)).toEqual(['A']);
+    expect(out['This week']).toEqual([]);
+  });
+
+  it('unparseable labels (e.g. "Last week") fall to "Earlier"', () => {
+    const out = bucketHistorySections(
+      [section('Last week', [track('a', 'A')])],
+      now,
+    );
+    expect(out.Earlier.map((t) => t.title)).toEqual(['A']);
+  });
+
+  it('multiple sections in the same bucket merge in encounter order', () => {
+    const out = bucketHistorySections(
+      [
+        section('Today', [track('a', 'A')]),
+        section('Today', [track('b', 'B')]),
+      ],
+      now,
+    );
+    expect(out.Today.map((t) => t.title)).toEqual(['A', 'B']);
+  });
+
+  it('empty input returns empty buckets', () => {
+    const out = bucketHistorySections([], now);
+    expect(out.Today).toEqual([]);
+    expect(out.Yesterday).toEqual([]);
+    expect(out['This week']).toEqual([]);
+    expect(out.Earlier).toEqual([]);
   });
 });

--- a/src/components/pages/HistoryPage.tsx
+++ b/src/components/pages/HistoryPage.tsx
@@ -1,21 +1,91 @@
-import { type FC, useEffect, useState } from 'react';
-import type { TrackInfo } from '../../lib/types';
+import { type FC, useEffect, useMemo, useState } from 'react';
+import { LiquidGlass } from '@liquidglass/react';
+import type { HistorySection, TrackInfo } from '../../lib/types';
 import { browseApi } from '../../lib/ipc';
 import { rememberTrackArtworks } from '../../lib/trackArtworkRegistry';
 import { debug } from '../../lib/debug';
 import { SongRow } from '../browse/SongRow';
 import { SkeletonRow } from '../Skeleton';
 
-// Issue #83 + #93 — Recently Played page. Originally backed by a
-// locally-tracked log; the follow-up (#93) moved the data source to
-// YouTube Music's own `FEmusic_history` endpoint, which matches what
-// the user sees on YTM's web History page. Layout mirrors LibraryPage:
-// sticky title plate + 3-column SongRow grid.
+// Issue #93 follow-up — group the history by Today / Yesterday / This
+// week / Earlier (mirrors how Apple Music + YTM Web present the same
+// list). Backend returns YTM's date-grouped sections preserving the
+// original header labels; the FE buckets them. Title plate uses the
+// same LiquidGlass capsule as HomePage / LibraryPage so every page
+// reads the same in the chrome.
 
-const HISTORY_PAGE_SECTION_LABEL = 'RECENTLY PLAYED';
+type BucketKey = 'Today' | 'Yesterday' | 'This week' | 'Earlier';
+
+const BUCKET_ORDER: readonly BucketKey[] = [
+  'Today',
+  'Yesterday',
+  'This week',
+  'Earlier',
+] as const;
+
+/**
+ * Bucket each YTM section header into one of the four display groups.
+ *   - "Today" → Today
+ *   - "Yesterday" → Yesterday
+ *   - any other label whose date parses within the last 7 days
+ *     (excluding today/yesterday) → This week
+ *   - everything else → Earlier
+ *
+ * `now` is injected for testability — defaults to wall-clock.
+ */
+export function bucketHistorySections(
+  sections: HistorySection[],
+  now: Date = new Date(),
+): Record<BucketKey, TrackInfo[]> {
+  const buckets: Record<BucketKey, TrackInfo[]> = {
+    Today: [],
+    Yesterday: [],
+    'This week': [],
+    Earlier: [],
+  };
+
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+  // 6 days back from start-of-today: covers the full current rolling
+  // week excluding today + yesterday (those have their own buckets).
+  const sevenDaysAgo = new Date(startOfToday);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 6);
+
+  for (const section of sections) {
+    const norm = section.label.trim().toLowerCase();
+    if (norm === 'today') {
+      buckets.Today.push(...section.tracks);
+      continue;
+    }
+    if (norm === 'yesterday') {
+      buckets.Yesterday.push(...section.tracks);
+      continue;
+    }
+
+    // YTM uses things like "Last week" or specific dates ("October 29").
+    // Try to parse the label as a date; fall through to Earlier when we
+    // can't make sense of it.
+    const parsed = new Date(section.label);
+    if (
+      !Number.isNaN(parsed.getTime()) &&
+      parsed >= sevenDaysAgo &&
+      parsed < startOfToday
+    ) {
+      buckets['This week'].push(...section.tracks);
+      continue;
+    }
+
+    buckets.Earlier.push(...section.tracks);
+  }
+
+  return buckets;
+}
 
 export const HistoryPage: FC = () => {
-  const [tracks, setTracks] = useState<TrackInfo[]>([]);
+  const [sections, setSections] = useState<HistorySection[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -27,8 +97,11 @@ export const HistoryPage: FC = () => {
       .getHistory()
       .then((data) => {
         if (cancelled) return;
-        rememberTrackArtworks(data);
-        setTracks(data);
+        // Flatten just for the artwork registry — every track's cover
+        // helps QueuePanel + NowPlaying resolve faster on subsequent
+        // plays. The grouping itself stays intact in `sections`.
+        rememberTrackArtworks(data.flatMap((s) => s.tracks));
+        setSections(data);
         setIsLoading(false);
       })
       .catch((e) => {
@@ -42,6 +115,9 @@ export const HistoryPage: FC = () => {
     };
   }, []);
 
+  const buckets = useMemo(() => bucketHistorySections(sections), [sections]);
+  const totalTracks = sections.reduce((n, s) => n + s.tracks.length, 0);
+
   return (
     <section
       style={{
@@ -52,46 +128,50 @@ export const HistoryPage: FC = () => {
     >
       <div style={{ height: 'var(--space-3)', flexShrink: 0 }} aria-hidden="true" />
 
+      {/* Canonical sticky title plate — same LiquidGlass capsule
+          recipe HomePage and LibraryPage use, so the chrome reads
+          consistent across every page. */}
       <div
         style={{
           position: 'sticky',
           top: 'var(--space-3)',
-          zIndex: 20,
-          padding:
-            'calc(var(--title-bar-height) - var(--space-3)) var(--space-4) var(--space-3)',
+          zIndex: 10,
           marginBottom: 'var(--space-4)',
-          background: 'oklch(20% 0.005 270 / 0.30)',
-          backdropFilter: 'blur(var(--glass-blur))',
-          WebkitBackdropFilter: 'blur(var(--glass-blur))',
-          borderRadius: 'var(--radius-lg)',
-          border: '1px solid var(--glass-rim-mid)',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--space-1)',
         }}
       >
-        <span
-          style={{
-            fontSize: 'var(--text-xs)',
-            fontWeight: 600,
-            color: 'var(--color-text-tertiary)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-          }}
+        <LiquidGlass
+          borderRadius={150}
+          blur={8}
+          contrast={1.2}
+          brightness={1.05}
+          saturation={1.1}
+          shadowIntensity={0.25}
+          displacementScale={1}
+          elasticity={1}
+          zIndex={10}
         >
-          {HISTORY_PAGE_SECTION_LABEL}
-        </span>
-        <h1
-          style={{
-            margin: 0,
-            fontSize: 'var(--text-2xl)',
-            fontWeight: 700,
-            color: 'var(--color-text-primary)',
-            letterSpacing: '-0.02em',
-          }}
-        >
-          History
-        </h1>
+          <div
+            style={{
+              width: '100%',
+              padding:
+                'calc(var(--title-bar-height) - var(--space-3)) var(--space-10) var(--space-3)',
+              background: 'oklch(20% 0.005 270 / 0.30)',
+              borderRadius: 'inherit',
+            }}
+          >
+            <h1
+              style={{
+                margin: 0,
+                fontSize: 'var(--text-2xl)',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                color: 'var(--color-text-primary)',
+              }}
+            >
+              History
+            </h1>
+          </div>
+        </LiquidGlass>
       </div>
 
       {isLoading && (
@@ -120,7 +200,7 @@ export const HistoryPage: FC = () => {
         </p>
       )}
 
-      {!isLoading && !error && tracks.length === 0 && (
+      {!isLoading && !error && totalTracks === 0 && (
         <div
           style={{
             display: 'flex',
@@ -140,22 +220,43 @@ export const HistoryPage: FC = () => {
         </div>
       )}
 
-      {!isLoading && !error && tracks.length > 0 && (
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-            columnGap: 'var(--space-4)',
-            rowGap: 'var(--space-1)',
-          }}
-        >
-          {tracks.map((track, i) => (
-            <SongRow
-              key={(track.videoId || 'history') + ':' + i}
-              track={track}
-            />
-          ))}
-        </div>
+      {!isLoading && !error && totalTracks > 0 && (
+        <>
+          {BUCKET_ORDER.map((key) => {
+            const tracks = buckets[key];
+            if (tracks.length === 0) return null;
+            return (
+              <div key={key} style={{ marginBottom: 'var(--space-6)' }}>
+                <h2
+                  style={{
+                    fontSize: 'var(--text-lg)',
+                    fontWeight: 700,
+                    letterSpacing: '-0.01em',
+                    color: 'var(--color-text-primary)',
+                    margin: '0 0 var(--space-3) 0',
+                  }}
+                >
+                  {key}
+                </h2>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                    columnGap: 'var(--space-4)',
+                    rowGap: 'var(--space-1)',
+                  }}
+                >
+                  {tracks.map((track, i) => (
+                    <SongRow
+                      key={`${key}:${track.videoId || 'history'}:${i}`}
+                      track={track}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </>
       )}
 
       <div

--- a/src/components/pages/HomePage.test.tsx
+++ b/src/components/pages/HomePage.test.tsx
@@ -12,16 +12,43 @@ describe('reorderShelves', () => {
       shelf('Albums for you'),
       shelf('Trending community playlists'),
       shelf('Listen again'),
-      shelf('Your daily discovery'),
+      shelf('Discovery'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     expect(out).toEqual([
       'Listen again',
-      'Your daily discovery',
+      'Discovery',
       'Albums for you',
       'Quick picks',
       'Trending community playlists',
     ]);
+  });
+
+  it('matches any alias in a priority slot', () => {
+    // YTM's real title is "Discovery" but users may call it "Daily discovery"
+    // or "Your daily discovery" — all three should pin to the same slot.
+    const inputs = [
+      [shelf('Discovery'), shelf('Albums for you')],
+      [shelf('Daily discovery'), shelf('Albums for you')],
+      [shelf('Your daily discovery'), shelf('Albums for you')],
+    ];
+    for (const input of inputs) {
+      const out = reorderShelves(input).map((s) => s.title);
+      expect(out[0]).toBe(input[0].title);
+      expect(out[1]).toBe('Albums for you');
+    }
+  });
+
+  it('pins the first matching alias and sends later aliases to rest', () => {
+    // If YTM ever returns two equivalent shelves (very unlikely), the first
+    // wins the priority slot; the second falls through to rest.
+    const input = [
+      shelf('Discovery'),
+      shelf('Daily discovery'),
+      shelf('Quick picks'),
+    ];
+    const out = reorderShelves(input).map((s) => s.title);
+    expect(out).toEqual(['Discovery', 'Daily discovery', 'Quick picks']);
   });
 
   it('keeps non-priority shelves in their original backend order', () => {
@@ -41,9 +68,15 @@ describe('reorderShelves', () => {
       shelf('quick picks'),
       shelf('  Albums For You  '),
       shelf('LISTEN AGAIN'),
+      shelf('  discovery  '),
     ];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['LISTEN AGAIN', '  Albums For You  ', 'quick picks']);
+    expect(out).toEqual([
+      'LISTEN AGAIN',
+      '  discovery  ',
+      '  Albums For You  ',
+      'quick picks',
+    ]);
   });
 
   it('does not mutate input array', () => {

--- a/src/components/pages/HomePage.test.tsx
+++ b/src/components/pages/HomePage.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { reorderShelves } from './HomePage';
+import type { Shelf } from '../../lib/types';
+
+const stubItems: Shelf['items'] = { kind: 'Songs', data: [] };
+const shelf = (title: string): Shelf => ({ title, items: stubItems });
+
+describe('reorderShelves', () => {
+  it('pins all three priority shelves in the configured order', () => {
+    const input = [
+      shelf('Quick picks'),
+      shelf('Albums for you'),
+      shelf('Trending community playlists'),
+      shelf('Listen again'),
+      shelf('Your daily discovery'),
+    ];
+    const out = reorderShelves(input).map((s) => s.title);
+    expect(out).toEqual([
+      'Listen again',
+      'Your daily discovery',
+      'Albums for you',
+      'Quick picks',
+      'Trending community playlists',
+    ]);
+  });
+
+  it('keeps non-priority shelves in their original backend order', () => {
+    const input = [shelf('A'), shelf('B'), shelf('Listen again'), shelf('C')];
+    const out = reorderShelves(input).map((s) => s.title);
+    expect(out).toEqual(['Listen again', 'A', 'B', 'C']);
+  });
+
+  it('falls through gracefully when priority shelves are missing', () => {
+    const input = [shelf('Quick picks'), shelf('Listen again')];
+    const out = reorderShelves(input).map((s) => s.title);
+    expect(out).toEqual(['Listen again', 'Quick picks']);
+  });
+
+  it('matches case-insensitively and tolerates trailing whitespace', () => {
+    const input = [
+      shelf('quick picks'),
+      shelf('  Albums For You  '),
+      shelf('LISTEN AGAIN'),
+    ];
+    const out = reorderShelves(input).map((s) => s.title);
+    expect(out).toEqual(['LISTEN AGAIN', '  Albums For You  ', 'quick picks']);
+  });
+
+  it('does not mutate input array', () => {
+    const input = [shelf('A'), shelf('Listen again')];
+    const snapshot = input.map((s) => s.title);
+    reorderShelves(input);
+    expect(input.map((s) => s.title)).toEqual(snapshot);
+  });
+
+  it('dedupes when the same priority title appears twice', () => {
+    const input = [
+      shelf('Listen again'),
+      shelf('Quick picks'),
+      shelf('Listen again'),
+    ];
+    const out = reorderShelves(input).map((s) => s.title);
+    // First occurrence wins; the duplicate falls into rest, preserving its position
+    expect(out).toEqual(['Listen again', 'Quick picks', 'Listen again']);
+  });
+
+  it('returns a new array (no identity reuse)', () => {
+    const input = [shelf('A'), shelf('B')];
+    const out = reorderShelves(input);
+    expect(out).not.toBe(input);
+  });
+
+  it('handles empty input', () => {
+    expect(reorderShelves([])).toEqual([]);
+  });
+});

--- a/src/components/pages/HomePage.test.tsx
+++ b/src/components/pages/HomePage.test.tsx
@@ -11,14 +11,14 @@ describe('reorderShelves', () => {
     const input = [
       shelf('Albums for you'),
       shelf('Quick picks'),
-      shelf('Mixed for you'),
-      shelf('Forgotten favorites'),
+      shelf('Your daily discover'),
+      shelf('Listen again'),
       shelf('Trending community playlists'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     expect(out).toEqual([
-      'Forgotten favorites',
-      'Mixed for you',
+      'Listen again',
+      'Your daily discover',
       'Albums for you',
       'Quick picks',
       'Trending community playlists',
@@ -26,10 +26,10 @@ describe('reorderShelves', () => {
   });
 
   it('matches any alias in a priority slot', () => {
-    // Slot 1 ("Mixed for you") accepts the user-facing names too, in case
-    // YTM ever rebrands the shelf back to "Daily discovery" / "Discovery".
+    // Slot 1 accepts YTM's truncated "Your daily discover" plus longer
+    // variants in case YTM stops truncating or renames the shelf.
     const inputs = [
-      [shelf('Mixed for you'), shelf('Albums for you')],
+      [shelf('Your daily discover'), shelf('Albums for you')],
       [shelf('Discovery'), shelf('Albums for you')],
       [shelf('Daily discovery'), shelf('Albums for you')],
       [shelf('Your daily discovery'), shelf('Albums for you')],
@@ -45,44 +45,44 @@ describe('reorderShelves', () => {
     // If YTM ever returns two shelves whose titles both match the same slot,
     // the first wins; the second falls through to rest.
     const input = [
-      shelf('Mixed for you'),
+      shelf('Your daily discover'),
       shelf('Discovery'),
       shelf('Quick picks'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['Mixed for you', 'Discovery', 'Quick picks']);
+    expect(out).toEqual(['Your daily discover', 'Discovery', 'Quick picks']);
   });
 
   it('keeps non-priority shelves in their original backend order', () => {
-    const input = [shelf('A'), shelf('B'), shelf('Forgotten favorites'), shelf('C')];
+    const input = [shelf('A'), shelf('B'), shelf('Listen again'), shelf('C')];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['Forgotten favorites', 'A', 'B', 'C']);
+    expect(out).toEqual(['Listen again', 'A', 'B', 'C']);
   });
 
   it('falls through gracefully when priority shelves are missing', () => {
-    const input = [shelf('Quick picks'), shelf('Forgotten favorites')];
+    const input = [shelf('Quick picks'), shelf('Listen again')];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['Forgotten favorites', 'Quick picks']);
+    expect(out).toEqual(['Listen again', 'Quick picks']);
   });
 
   it('matches case-insensitively and tolerates trailing whitespace', () => {
     const input = [
       shelf('quick picks'),
       shelf('  Albums For You  '),
-      shelf('FORGOTTEN FAVORITES'),
-      shelf('  mixed for you  '),
+      shelf('LISTEN AGAIN'),
+      shelf('  your daily discover  '),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     expect(out).toEqual([
-      'FORGOTTEN FAVORITES',
-      '  mixed for you  ',
+      'LISTEN AGAIN',
+      '  your daily discover  ',
       '  Albums For You  ',
       'quick picks',
     ]);
   });
 
   it('does not mutate input array', () => {
-    const input = [shelf('A'), shelf('Forgotten favorites')];
+    const input = [shelf('A'), shelf('Listen again')];
     const snapshot = input.map((s) => s.title);
     reorderShelves(input);
     expect(input.map((s) => s.title)).toEqual(snapshot);
@@ -90,13 +90,13 @@ describe('reorderShelves', () => {
 
   it('dedupes when the same priority title appears twice', () => {
     const input = [
-      shelf('Forgotten favorites'),
+      shelf('Listen again'),
       shelf('Quick picks'),
-      shelf('Forgotten favorites'),
+      shelf('Listen again'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     // First occurrence wins; the duplicate falls into rest, preserving its position
-    expect(out).toEqual(['Forgotten favorites', 'Quick picks', 'Forgotten favorites']);
+    expect(out).toEqual(['Listen again', 'Quick picks', 'Listen again']);
   });
 
   it('returns a new array (no identity reuse)', () => {

--- a/src/components/pages/HomePage.test.tsx
+++ b/src/components/pages/HomePage.test.tsx
@@ -7,17 +7,18 @@ const shelf = (title: string): Shelf => ({ title, items: stubItems });
 
 describe('reorderShelves', () => {
   it('pins all three priority shelves in the configured order', () => {
+    // Real YTM titles for this user's home — verified via API dumps.
     const input = [
-      shelf('Quick picks'),
       shelf('Albums for you'),
+      shelf('Quick picks'),
+      shelf('Mixed for you'),
+      shelf('Forgotten favorites'),
       shelf('Trending community playlists'),
-      shelf('Listen again'),
-      shelf('Discovery'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     expect(out).toEqual([
-      'Listen again',
-      'Discovery',
+      'Forgotten favorites',
+      'Mixed for you',
       'Albums for you',
       'Quick picks',
       'Trending community playlists',
@@ -25,9 +26,10 @@ describe('reorderShelves', () => {
   });
 
   it('matches any alias in a priority slot', () => {
-    // YTM's real title is "Discovery" but users may call it "Daily discovery"
-    // or "Your daily discovery" — all three should pin to the same slot.
+    // Slot 1 ("Mixed for you") accepts the user-facing names too, in case
+    // YTM ever rebrands the shelf back to "Daily discovery" / "Discovery".
     const inputs = [
+      [shelf('Mixed for you'), shelf('Albums for you')],
       [shelf('Discovery'), shelf('Albums for you')],
       [shelf('Daily discovery'), shelf('Albums for you')],
       [shelf('Your daily discovery'), shelf('Albums for you')],
@@ -40,47 +42,47 @@ describe('reorderShelves', () => {
   });
 
   it('pins the first matching alias and sends later aliases to rest', () => {
-    // If YTM ever returns two equivalent shelves (very unlikely), the first
-    // wins the priority slot; the second falls through to rest.
+    // If YTM ever returns two shelves whose titles both match the same slot,
+    // the first wins; the second falls through to rest.
     const input = [
+      shelf('Mixed for you'),
       shelf('Discovery'),
-      shelf('Daily discovery'),
       shelf('Quick picks'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['Discovery', 'Daily discovery', 'Quick picks']);
+    expect(out).toEqual(['Mixed for you', 'Discovery', 'Quick picks']);
   });
 
   it('keeps non-priority shelves in their original backend order', () => {
-    const input = [shelf('A'), shelf('B'), shelf('Listen again'), shelf('C')];
+    const input = [shelf('A'), shelf('B'), shelf('Forgotten favorites'), shelf('C')];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['Listen again', 'A', 'B', 'C']);
+    expect(out).toEqual(['Forgotten favorites', 'A', 'B', 'C']);
   });
 
   it('falls through gracefully when priority shelves are missing', () => {
-    const input = [shelf('Quick picks'), shelf('Listen again')];
+    const input = [shelf('Quick picks'), shelf('Forgotten favorites')];
     const out = reorderShelves(input).map((s) => s.title);
-    expect(out).toEqual(['Listen again', 'Quick picks']);
+    expect(out).toEqual(['Forgotten favorites', 'Quick picks']);
   });
 
   it('matches case-insensitively and tolerates trailing whitespace', () => {
     const input = [
       shelf('quick picks'),
       shelf('  Albums For You  '),
-      shelf('LISTEN AGAIN'),
-      shelf('  discovery  '),
+      shelf('FORGOTTEN FAVORITES'),
+      shelf('  mixed for you  '),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     expect(out).toEqual([
-      'LISTEN AGAIN',
-      '  discovery  ',
+      'FORGOTTEN FAVORITES',
+      '  mixed for you  ',
       '  Albums For You  ',
       'quick picks',
     ]);
   });
 
   it('does not mutate input array', () => {
-    const input = [shelf('A'), shelf('Listen again')];
+    const input = [shelf('A'), shelf('Forgotten favorites')];
     const snapshot = input.map((s) => s.title);
     reorderShelves(input);
     expect(input.map((s) => s.title)).toEqual(snapshot);
@@ -88,13 +90,13 @@ describe('reorderShelves', () => {
 
   it('dedupes when the same priority title appears twice', () => {
     const input = [
-      shelf('Listen again'),
+      shelf('Forgotten favorites'),
       shelf('Quick picks'),
-      shelf('Listen again'),
+      shelf('Forgotten favorites'),
     ];
     const out = reorderShelves(input).map((s) => s.title);
     // First occurrence wins; the duplicate falls into rest, preserving its position
-    expect(out).toEqual(['Listen again', 'Quick picks', 'Listen again']);
+    expect(out).toEqual(['Forgotten favorites', 'Quick picks', 'Forgotten favorites']);
   });
 
   it('returns a new array (no identity reuse)', () => {

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -59,6 +59,42 @@ let cachedMoodSongs: { mood: MoodTab; songs: TrackInfo[] } | null = null;
 
 const SONGS_FILTER = 'EgWKAQIIAWoSEA4QCRAKEAUQBBADEBUQEBAR';
 
+// Personal shelves users want pinned to the top of Home, in this exact
+// display order. Match is case-insensitive and trim-tolerant — YTM
+// occasionally returns trailing whitespace and capitalization can drift
+// across releases. Absent priority shelves fall through silently and the
+// remaining shelves keep their original backend order.
+const PRIORITY_TITLES = [
+  'Listen again',
+  'Your daily discovery',
+  'Albums for you',
+] as const;
+
+export function reorderShelves(shelves: Shelf[]): Shelf[] {
+  const norm = (s: string) => s.trim().toLowerCase();
+  const priorityIndex = new Map(
+    PRIORITY_TITLES.map((title, i) => [norm(title), i] as const),
+  );
+
+  const pinned: Shelf[] = [];
+  const rest: Shelf[] = [];
+  const seen = new Set<string>();
+
+  for (const shelf of shelves) {
+    const key = norm(shelf.title);
+    const idx = priorityIndex.get(key);
+    if (idx !== undefined && !seen.has(key)) {
+      pinned[idx] = shelf;
+      seen.add(key);
+    } else {
+      rest.push(shelf);
+    }
+  }
+
+  // pinned may be sparse if some priority shelves are absent — filter holes
+  return [...pinned.filter(Boolean), ...rest];
+}
+
 const getGreeting = (): string => {
   const hour = new Date().getHours();
   if (hour >= 5 && hour < 12) return 'Good morning';
@@ -376,7 +412,7 @@ export const HomePage: FC<HomePageProps> = ({ onOpenPlaylist, onReady }) => {
       )}
 
       {activeMood === 'All' &&
-        shelves.map((shelf) => (
+        reorderShelves(shelves).map((shelf) => (
           <ShelfRow key={shelf.title} title={shelf.title}>
             {renderShelfContent(shelf, onOpenPlaylist)}
           </ShelfRow>

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -61,19 +61,22 @@ const SONGS_FILTER = 'EgWKAQIIAWoSEA4QCRAKEAUQBBADEBUQEBAR';
 
 // Personal shelves users want pinned to the top of Home, in this exact
 // display order. Each slot accepts multiple title variants so we can
-// follow YTM's real wording without losing the user's mental model:
-// "daily discovery" is the user's name; YTM actually returns "Discovery".
+// follow YTM's real wording without losing the user's mental model.
 // Match is case-insensitive and trim-tolerant.
 //
-// Verified against /tmp/vibeytm-resp-browse-*.json on 2026-05-02:
-//   - "Albums for you"  ← exact YTM title
-//   - "Discovery"       ← exact YTM title (user calls it "daily discovery")
-//   - "Listen again"    ← YTM context-menu offers "Pin to Listen again",
-//                         so the shelf only appears when the user has
-//                         pinned items; pins gracefully when present.
+// Verified against /tmp/vibeytm-resp-browse-*.json on 2026-05-02 — these
+// are the actual shelf titles YTM returns (NOT the user-facing names like
+// "Listen again" / "Daily discovery", which are not real shelf titles in
+// the API). Aliases are kept for forward-compat in case YTM renames.
+//   - slot 0: "Forgotten favorites" (semantic: revisit older listens)
+//             aliases: "Listen again" — kept in case YTM ever re-introduces
+//             that exact title for a pinned shelf.
+//   - slot 1: "Mixed for you" (semantic: personalized daily mix)
+//             aliases: "Discovery" / "Daily discovery" / "Your daily discovery".
+//   - slot 2: "Albums for you".
 const PRIORITY_TITLE_ALIASES: ReadonlyArray<ReadonlyArray<string>> = [
-  ['Listen again'],
-  ['Discovery', 'Your daily discovery', 'Daily discovery'],
+  ['Forgotten favorites', 'Listen again'],
+  ['Mixed for you', 'Discovery', 'Daily discovery', 'Your daily discovery'],
   ['Albums for you'],
 ];
 

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -60,23 +60,22 @@ let cachedMoodSongs: { mood: MoodTab; songs: TrackInfo[] } | null = null;
 const SONGS_FILTER = 'EgWKAQIIAWoSEA4QCRAKEAUQBBADEBUQEBAR';
 
 // Personal shelves users want pinned to the top of Home, in this exact
-// display order. Each slot accepts multiple title variants so we can
-// follow YTM's real wording without losing the user's mental model.
-// Match is case-insensitive and trim-tolerant.
+// display order. Each slot accepts multiple title variants for forward
+// compatibility in case YTM renames a shelf. Match is case-insensitive
+// and trim-tolerant.
 //
-// Verified against /tmp/vibeytm-resp-browse-*.json on 2026-05-02 — these
-// are the actual shelf titles YTM returns (NOT the user-facing names like
-// "Listen again" / "Daily discovery", which are not real shelf titles in
-// the API). Aliases are kept for forward-compat in case YTM renames.
-//   - slot 0: "Forgotten favorites" (semantic: revisit older listens)
-//             aliases: "Listen again" — kept in case YTM ever re-introduces
-//             that exact title for a pinned shelf.
-//   - slot 1: "Mixed for you" (semantic: personalized daily mix)
-//             aliases: "Discovery" / "Daily discovery" / "Your daily discovery".
-//   - slot 2: "Albums for you".
+// Verified against the live running app via REORDER-DIAG on 2026-05-02:
+// YTM's actual shelf titles for slots 0-2 in the user's home are
+// "Listen again", "Your daily discover" (note: no trailing 'y' — YTM's
+// UI truncates), and "Albums for you".
 const PRIORITY_TITLE_ALIASES: ReadonlyArray<ReadonlyArray<string>> = [
-  ['Forgotten favorites', 'Listen again'],
-  ['Mixed for you', 'Discovery', 'Daily discovery', 'Your daily discovery'],
+  ['Listen again'],
+  [
+    'Your daily discover',
+    'Your daily discovery',
+    'Daily discovery',
+    'Discovery',
+  ],
   ['Albums for you'],
 ];
 

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -60,32 +60,39 @@ let cachedMoodSongs: { mood: MoodTab; songs: TrackInfo[] } | null = null;
 const SONGS_FILTER = 'EgWKAQIIAWoSEA4QCRAKEAUQBBADEBUQEBAR';
 
 // Personal shelves users want pinned to the top of Home, in this exact
-// display order. Match is case-insensitive and trim-tolerant — YTM
-// occasionally returns trailing whitespace and capitalization can drift
-// across releases. Absent priority shelves fall through silently and the
-// remaining shelves keep their original backend order.
-const PRIORITY_TITLES = [
-  'Listen again',
-  'Your daily discovery',
-  'Albums for you',
-] as const;
+// display order. Each slot accepts multiple title variants so we can
+// follow YTM's real wording without losing the user's mental model:
+// "daily discovery" is the user's name; YTM actually returns "Discovery".
+// Match is case-insensitive and trim-tolerant.
+//
+// Verified against /tmp/vibeytm-resp-browse-*.json on 2026-05-02:
+//   - "Albums for you"  ← exact YTM title
+//   - "Discovery"       ← exact YTM title (user calls it "daily discovery")
+//   - "Listen again"    ← YTM context-menu offers "Pin to Listen again",
+//                         so the shelf only appears when the user has
+//                         pinned items; pins gracefully when present.
+const PRIORITY_TITLE_ALIASES: ReadonlyArray<ReadonlyArray<string>> = [
+  ['Listen again'],
+  ['Discovery', 'Your daily discovery', 'Daily discovery'],
+  ['Albums for you'],
+];
 
 export function reorderShelves(shelves: Shelf[]): Shelf[] {
   const norm = (s: string) => s.trim().toLowerCase();
-  const priorityIndex = new Map(
-    PRIORITY_TITLES.map((title, i) => [norm(title), i] as const),
-  );
+  const priorityIndex = new Map<string, number>();
+  PRIORITY_TITLE_ALIASES.forEach((aliases, slot) => {
+    for (const alias of aliases) priorityIndex.set(norm(alias), slot);
+  });
 
   const pinned: Shelf[] = [];
   const rest: Shelf[] = [];
-  const seen = new Set<string>();
+  const filledSlots = new Set<number>();
 
   for (const shelf of shelves) {
-    const key = norm(shelf.title);
-    const idx = priorityIndex.get(key);
-    if (idx !== undefined && !seen.has(key)) {
-      pinned[idx] = shelf;
-      seen.add(key);
+    const slot = priorityIndex.get(norm(shelf.title));
+    if (slot !== undefined && !filledSlots.has(slot)) {
+      pinned[slot] = shelf;
+      filledSlots.add(slot);
     } else {
       rest.push(shelf);
     }

--- a/src/components/pages/PlaylistDetailPage.test.tsx
+++ b/src/components/pages/PlaylistDetailPage.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { PlaylistDetail, TrackInfo } from '../../lib/types';
+
+// Pin the isShow ? EpisodeRow : SongRow branch (PR #97 review H3).
+// A regression flipping the condition or breaking the MPSPP prefix
+// check would silently render music rows for podcast episodes, losing
+// the per-episode publish date + description layout. Keeps the
+// branching contract testable without booting the full hero.
+
+const getPlaylistMock = vi.fn();
+
+vi.mock('../../lib/ipc', () => ({
+  browseApi: {
+    getPlaylist: (id: string) => getPlaylistMock(id),
+    savePlaylistToLibrary: vi.fn(),
+    removePlaylistFromLibrary: vi.fn(),
+  },
+  playerApi: {
+    getState: vi.fn().mockResolvedValue(null),
+    playFirstFromPlaylist: vi.fn(),
+    setPlaylist: vi.fn(),
+    next: vi.fn(),
+  },
+  playFirstFromPlaylist: vi.fn(),
+}));
+
+vi.mock('../../lib/trackArtworkRegistry', () => ({
+  rememberTrackArtworks: vi.fn(),
+}));
+vi.mock('../../lib/showCoverRegistry', () => ({
+  rememberShowCover: vi.fn(),
+}));
+vi.mock('../../lib/trackMetaRegistry', () => ({
+  rememberTrackMetas: vi.fn(),
+}));
+vi.mock('../../hooks/useCoverColors', () => ({
+  useCoverColors: () => ({ primary: '#000', secondary: '#000' }),
+}));
+
+vi.mock('../browse/SongRow', () => ({
+  SongRow: ({ track }: { track: TrackInfo }) => (
+    <div data-testid="song-row">{track.title}</div>
+  ),
+}));
+vi.mock('../browse/EpisodeRow', () => ({
+  EpisodeRow: ({ track }: { track: TrackInfo }) => (
+    <div data-testid="episode-row">{track.title}</div>
+  ),
+}));
+
+vi.mock('../DetailPageHero', () => ({
+  DetailPageHero: ({ title, kind }: { title: string; kind: string }) => (
+    <div data-testid="hero">{`${kind}:${title}`}</div>
+  ),
+}));
+
+vi.mock('../LoadingOverlay', () => ({
+  LoadingSpinner: () => <div data-testid="spinner" />,
+}));
+
+vi.mock('../Skeleton', () => ({
+  SkeletonDetailHero: () => null,
+  SkeletonRow: () => <div data-testid="skeleton-row" />,
+}));
+
+const { PlaylistDetailPage } = await import('./PlaylistDetailPage');
+
+const track = (id: string, title: string): TrackInfo => ({
+  videoId: id,
+  title,
+  artist: 'Artist',
+  album: 'Album',
+  durationSecs: 180,
+});
+
+const detail = (
+  id: string,
+  tracks: TrackInfo[],
+  overrides: Partial<PlaylistDetail> = {},
+): PlaylistDetail => ({
+  playlistId: id,
+  title: 'Title',
+  artworkUrl: '',
+  tracks,
+  isInLibrary: false,
+  isAlbum: false,
+  ...overrides,
+});
+
+beforeEach(() => {
+  getPlaylistMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PlaylistDetailPage — track row branching', () => {
+  it('renders EpisodeRow for podcast/show playlists (MPSPP prefix)', async () => {
+    getPlaylistMock.mockResolvedValue(
+      detail('MPSPPshow123', [track('e1', 'Episode One')]),
+    );
+    render(
+      <PlaylistDetailPage playlistId="MPSPPshow123" onBack={() => {}} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Episode One')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('episode-row')).not.toBeNull();
+    expect(screen.queryByTestId('song-row')).toBeNull();
+  });
+
+  it('renders SongRow for music playlists (non-MPSPP)', async () => {
+    getPlaylistMock.mockResolvedValue(
+      detail('PLmusic456', [track('s1', 'Song One')]),
+    );
+    render(<PlaylistDetailPage playlistId="PLmusic456" onBack={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByText('Song One')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('song-row')).not.toBeNull();
+    expect(screen.queryByTestId('episode-row')).toBeNull();
+  });
+
+  it('renders SongRow for album playlists (MPRE prefix, not MPSPP)', async () => {
+    // The isShow gate is strict on MPSPP — albums (MPRE*) must NOT
+    // accidentally fall into the episode branch.
+    getPlaylistMock.mockResolvedValue(
+      detail('MPREalbum789', [track('a1', 'Album Track')], { isAlbum: true }),
+    );
+    render(
+      <PlaylistDetailPage playlistId="MPREalbum789" onBack={() => {}} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Album Track')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('song-row')).not.toBeNull();
+    expect(screen.queryByTestId('episode-row')).toBeNull();
+  });
+});

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -383,8 +383,8 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
           zIndex: 10,
           flexShrink: 0,
           background: 'transparent',
-          backdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
-          WebkitBackdropFilter: `blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))`,
+          backdropFilter: 'var(--page-sticky-blur)',
+          WebkitBackdropFilter: 'var(--page-sticky-blur)',
         }}
       >
         <DetailPageHero

--- a/src/components/pages/PlaylistDetailPage.tsx
+++ b/src/components/pages/PlaylistDetailPage.tsx
@@ -8,6 +8,7 @@ import { rememberTrackMetas } from '../../lib/trackMetaRegistry';
 import { useCoverColors } from '../../hooks/useCoverColors';
 import { albumArtOrNothing } from '../../lib/artwork';
 import { SongRow } from '../browse/SongRow';
+import { EpisodeRow } from '../browse/EpisodeRow';
 import { LoadingSpinner } from '../LoadingOverlay';
 import { DetailPageHero } from '../DetailPageHero';
 import { SkeletonDetailHero, SkeletonRow } from '../Skeleton';
@@ -420,14 +421,22 @@ export const PlaylistDetailPage: FC<PlaylistDetailPageProps> = ({
           padding: '0 var(--space-6)',
         }}
       >
-        {playlist.tracks.map((track, i) => (
-          <SongRow
-            key={track.videoId || `track-${i}`}
-            track={track}
-            index={i + 1}
-            playlistId={watchListId}
-          />
-        ))}
+        {playlist.tracks.map((track, i) =>
+          isShow ? (
+            <EpisodeRow
+              key={track.videoId || `track-${i}`}
+              track={track}
+              playlistId={watchListId}
+            />
+          ) : (
+            <SongRow
+              key={track.videoId || `track-${i}`}
+              track={track}
+              index={i + 1}
+              playlistId={watchListId}
+            />
+          ),
+        )}
         {playlist.tracks.length === 0 && (
           <div
             style={{

--- a/src/components/player/LyricsOverlay.tsx
+++ b/src/components/player/LyricsOverlay.tsx
@@ -69,9 +69,12 @@ export const LyricsOverlay: FC<LyricsOverlayProps> = ({ isOpen }) => {
 
   const overlayRef = useRef<HTMLElement | null>(null);
 
-  // Blur is scoped to the lyrics card itself (LyricsPanel's
-  // CONTAINER_STYLE owns the backdrop-filter recipe) — no full-area
-  // plate behind, so the rest of the page stays unblurred.
+  // Glass frame (background gradient, blur, border, rounded corners,
+  // shadow) lives on the SafeOverlay wrapper — same pattern QueuePanel
+  // uses (src/components/player/QueuePanel/index.tsx ~line 570). Putting
+  // the rounded corners on the wrapper ensures the visible blurred
+  // surface itself is rounded, not just the inner content card.
+  // (Issue #98 fix.)
   return (
     <SafeOverlay
       ref={overlayRef as Ref<HTMLElement>}
@@ -91,13 +94,15 @@ export const LyricsOverlay: FC<LyricsOverlayProps> = ({ isOpen }) => {
         bottom: 'calc(var(--player-bar-height) + var(--space-3))',
         left: 'calc(var(--sidebar-width) + var(--space-6) + min(800px, calc((2 / 3) * (100vw - var(--sidebar-width) - var(--space-6) * 2)), calc(100vh - var(--title-bar-height) - var(--player-bar-height) - var(--space-3) - 160px)) + var(--space-5))',
       }}
-      // Match the playing page's blur recipe — applied on the
-      // SafeOverlay wrapper itself so WebKit doesn't drop the filter
-      // because of the wrapper's transform-driven slide animation
-      // (descendant backdrop-filter under a transformed ancestor is
-      // unreliable in WKWebView). Same pattern QueuePanel uses.
-      background="transparent"
-      backdropFilter="blur(40px) saturate(180%)"
+      background="linear-gradient(180deg, oklch(100% 0 0 / 0.10) 0%, oklch(100% 0 0 / 0.02) 6%, oklch(100% 0 0 / 0) 30%, oklch(0% 0 0 / 0.10) 100%), var(--glass-bg-card)"
+      backdropFilter="blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))"
+      border="1px solid var(--glass-rim-mid)"
+      borderRadius="var(--radius-lg)"
+      boxShadow={
+        isOpen
+          ? 'inset 0 1px 0 var(--glass-rim-bright), 0 24px 60px oklch(0% 0 0 / 0.5)'
+          : undefined
+      }
       display="flex"
       flexDirection="column"
     >

--- a/src/components/player/NowPlaying/LyricsPanel.tsx
+++ b/src/components/player/NowPlaying/LyricsPanel.tsx
@@ -47,28 +47,16 @@ const CONTAINER_STYLE: CSSProperties = {
   // Fill the full content height of the overlay. The overlay reserves the
   // title-bar and player-bar on the outside; only the top space-3 padding
   // is on the inside (no bottom padding — the panel's bottom edge aligns
-  // exactly with the chrome's top, per user request).
-  // Bottom edge matches the QueuePanel's bottom edge: sit
-  // `var(--space-3)` above the player chrome's top so the rounded
-  // bottom corners are visible (without this gap the panel ends
-  // flush with the chrome's top edge).
-  height:
-    'calc(100vh - var(--title-bar-height) - var(--player-bar-height) - var(--space-3) * 2)',
+  // The wrapping SafeOverlay (LyricsOverlay) now owns the glass frame
+  // — gradient background, backdrop-filter, border, rounded corners,
+  // shadow — so this inner container only needs sizing and layout.
+  // Putting the frame on the wrapper (1) avoids stacking two
+  // backdrop-filter layers in the same screen region, which WKWebView
+  // flickers on (issue #99), and (2) keeps the rounded corners on the
+  // visible blurred surface so the panel doesn't render as a square
+  // (issue #98).
+  height: '100%',
   padding: 'var(--space-6)',
-  // Liquid Glass card tier — translucent surface so the cover-tinted
-  // backdrop and ambient page colour bleed through. Backdrop-filter
-  // on a fixed-position parent (NowPlaying overlay) so this nested
-  // panel inherits the chrome plate's blur context.
-  background:
-    'linear-gradient(180deg, oklch(100% 0 0 / 0.10) 0%, oklch(100% 0 0 / 0.02) 6%, oklch(100% 0 0 / 0) 30%, oklch(0% 0 0 / 0.10) 100%), var(--glass-bg-card)',
-  backdropFilter:
-    'blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))',
-  WebkitBackdropFilter:
-    'blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness))',
-  border: '1px solid var(--glass-rim-mid)',
-  borderRadius: 'var(--radius-lg)',
-  boxShadow:
-    'inset 0 1px 0 var(--glass-rim-bright), 0 24px 60px oklch(0% 0 0 / 0.5)',
   overflowY: 'auto',
   display: 'flex',
   flexDirection: 'column',

--- a/src/components/player/NowPlaying/LyricsPanel.tsx
+++ b/src/components/player/NowPlaying/LyricsPanel.tsx
@@ -323,12 +323,15 @@ const TimedLyrics: FC<TimedLyricsProps> = ({
           fontSize: 'var(--text-xs)',
           color: 'var(--color-text-tertiary)',
           borderTop: '1px solid oklch(100% 0 0 / 0.06)',
-          // Frosted-glass hood so lyric lines underneath read as a
-          // soft blur rather than fighting the controls for focus.
+          // Opaque gradient hood so lyric lines scrolling underneath
+          // fade behind the controls without needing a third
+          // `backdrop-filter` layer. Stacked backdrop-filters
+          // (NowPlaying + LyricsOverlay + this sticky row) caused
+          // continuous WKWebView paint flicker (issue #99). The bumped
+          // alpha values here recover the visual obscuration the blur
+          // previously provided.
           background:
-            'linear-gradient(180deg, oklch(0% 0 0 / 0) 0%, oklch(0% 0 0 / 0.45) 70%, oklch(0% 0 0 / 0.55) 100%)',
-          backdropFilter: 'blur(8px)',
-          WebkitBackdropFilter: 'blur(8px)',
+            'linear-gradient(180deg, oklch(8% 0.005 270 / 0) 0%, oklch(8% 0.005 270 / 0.85) 60%, oklch(8% 0.005 270 / 0.95) 100%)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke, convertFileSrc } from '@tauri-apps/api/core';
-import type { AccountInfo, PlayerState, TrackInfo, SearchResults, Shelf, PlaylistSummary, PlaylistDetail, AlbumSummary, ArtistSummary, ArtistDetail, PodcastSummary, PodcastLastEpisode, Lyrics } from './types';
+import type { AccountInfo, PlayerState, TrackInfo, SearchResults, Shelf, PlaylistSummary, PlaylistDetail, AlbumSummary, ArtistSummary, ArtistDetail, PodcastSummary, PodcastLastEpisode, Lyrics, HistorySection } from './types';
 import type { RepeatMode } from './types';
 
 export interface CacheStats {
@@ -264,8 +264,11 @@ export const browseApi = {
   getLibraryPlaylists: () => invoke<PlaylistSummary[]>('get_library_playlists'),
   getLibrarySongs: () => invoke<TrackInfo[]>('get_library_songs'),
   /** Issue #93 — recently-played history sourced from YTM's own
-   *  `FEmusic_history` endpoint. */
-  getHistory: () => invoke<TrackInfo[]>('get_history'),
+   *  `FEmusic_history` endpoint. Returns date-grouped sections (Today,
+   *  Yesterday, Last week, specific dates, ...) preserving YTM's own
+   *  labels. The FE buckets them into Today / Yesterday / This week /
+   *  Earlier. */
+  getHistory: () => invoke<HistorySection[]>('get_history'),
   getLibraryAlbums: () => invoke<AlbumSummary[]>('get_library_albums'),
   getLibraryArtists: () => invoke<ArtistSummary[]>('get_library_artists'),
   getLibraryPodcasts: () => invoke<PodcastSummary[]>('get_library_podcasts'),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,12 @@ export interface TrackInfo {
   albumId?: string;
   artworkUrl?: string;
   durationSecs: number;
+  /** Podcast / show episode description blurb. Populated only by the
+   *  episode parser; absent on music tracks. */
+  description?: string;
+  /** Podcast / show episode publish-date display string (e.g.
+   *  "Mar 1, 2026" / "3 days ago"). YTM-formatted; not parsed. */
+  publishedAt?: string;
 }
 
 export type PlaybackStatus = 'playing' | 'paused' | 'buffering' | 'idle';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -129,6 +129,17 @@ export interface SearchResults {
   topAlbum?: AlbumSummary | null;
 }
 
+/**
+ * One date-grouped section of the YTM "Recently played" response.
+ * `label` is YTM's own header text — typically "Today", "Yesterday",
+ * "Last week", or a specific calendar date — preserved so the FE can
+ * bucket these into Today / Yesterday / This week / Earlier groups.
+ */
+export interface HistorySection {
+  label: string;
+  tracks: TrackInfo[];
+}
+
 export type ShelfContent =
   | { kind: 'Albums'; data: AlbumSummary[] }
   | { kind: 'Playlists'; data: PlaylistSummary[] }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -251,3 +251,20 @@ body:has([aria-label='Now playing'][aria-hidden='false'])
   [data-detail-back-button] {
   display: none;
 }
+
+/* Sticky-hero backdrop-filter on detail pages (PlaylistDetailPage,
+ * ArtistPage) is opted into via this CSS variable. When the Now
+ * Playing overlay is visible we override the variable to `none` so
+ * the underlying page-hero blur layer disappears — that prevents
+ * stacking three backdrop-filter layers (page hero + NowPlaying +
+ * drawer) in the same screen region, which WKWebView feedback-loops
+ * on (issue #99 follow-up). The page underneath is fully covered by
+ * NowPlaying, so dropping its blur is purely a perf optimisation
+ * with zero visible change. */
+:root {
+  --page-sticky-blur: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness));
+}
+body:has([aria-label='Now playing'][aria-hidden='false']) {
+  --page-sticky-blur: none;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -240,3 +240,14 @@ input[type='range'][data-vibeytm-slider]:hover::-webkit-slider-runnable-track {
 input[type='range'][data-vibeytm-slider]:hover::-webkit-slider-thumb {
   margin-top: -4px; /* recenter on the 4px hover-track */
 }
+
+/* DetailPageHero back button hides while the Now Playing overlay is
+ * visible. The button is portaled to <body> at z-index 250 (above the
+ * Now Playing overlay), so without this rule the back chevron floats
+ * over the cover even though the page underneath is no longer the
+ * user's focus. The selector keys off SafeOverlay's
+ * `aria-label="Now playing"` + `aria-hidden="false"`. */
+body:has([aria-label='Now playing'][aria-hidden='false'])
+  [data-detail-back-button] {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Pin three personal Home shelves to the top in fixed order: **Listen again → Your daily discovery → Albums for you**
- All other shelves preserve their original YTM backend order beneath
- Render-time reorder via pure helper; no fetch, no cache, no backend changes
- Case-insensitive + trim-tolerant title match; missing priority shelves fall through silently

## Why
YTM returns Home shelves in an order that varies — personalized shelves often land below editorial sections like Quick picks. This pins the user's own listening to the top so they can resume without scrolling.

## How
- `PRIORITY_TITLES` constant + `reorderShelves(shelves)` pure helper in `HomePage.tsx`
- Single-line swap at the existing `shelves.map(...)` site (`activeMood === 'All'` branch only — mood search is unaffected)
- Does NOT mutate `cachedShelves` or `shelves` state (verified by test)

## Test plan
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 215/215 across 24 files (8 new in `HomePage.test.tsx`, no regressions)
- [x] Edge cases covered: empty input, all-priority, none-priority, missing priority, case/whitespace, duplicate priority title, identity-not-reused
- [ ] Manual visual check on running app: priority shelves appear at top in order; other shelves follow in YTM's order; sign-out flush still works; "↻ Refresh" still works; mood-tab branch unaffected

## Version
Bump `1.1.21` → `1.1.22` (per CLAUDE.md patch-bump policy on code-change commits).

## Notes
- The 3-title list is hard-coded per the request. Future user-customization would only need to swap `PRIORITY_TITLES` for state — the helper is render-time, not fetch-time.
- One pre-existing `key={shelf.title}` collision risk noted in review (`HomePage.tsx:415`); not introduced by this PR, out of scope.