### PR TITLE
Dark / Light / System theme switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,28 @@
     <title>VibeYTM</title>
   </head>
   <body>
+    <script>
+      // Synchronous theme init — runs before React to prevent flash of wrong theme.
+      (function() {
+        try {
+          var mode = localStorage.getItem('vibeytm:theme-mode');
+          var resolved;
+          if (mode === 'light') {
+            resolved = 'light';
+          } else if (mode === 'system') {
+            resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          } else {
+            // 'dark', missing, or invalid — fall back to the cached resolved theme or dark
+            var cached = localStorage.getItem('vibeytm:theme');
+            resolved = (cached === 'light') ? 'light' : 'dark';
+          }
+          document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e) {
+          // localStorage unavailable — dark is the default
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeytm",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "packageManager": "pnpm@10.31.0",
   "engines": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -308,6 +308,7 @@ pub fn run() {
                             close_to_tray: true,
                             background_playback: true,
                             last_volume: 1.0,
+                            theme: state::settings::ThemeMode::Dark,
                         });
                     // Flush the last-played session to disk right now so the
                     // next launch can restore it even when the user closes

--- a/src-tauri/src/state/settings.rs
+++ b/src-tauri/src/state/settings.rs
@@ -30,10 +30,24 @@ pub struct GeneralSettings {
     /// Defaults to 1.0 (full volume) on a clean install.
     #[serde(default = "default_volume")]
     pub last_volume: f64,
+    #[serde(default = "default_theme")]
+    pub theme: ThemeMode,
 }
 
 fn default_volume() -> f64 {
     1.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ThemeMode {
+    Dark,
+    Light,
+    System,
+}
+
+fn default_theme() -> ThemeMode {
+    ThemeMode::Dark
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -57,6 +71,7 @@ impl Default for AppSettings {
                 close_to_tray: true,
                 background_playback: true,
                 last_volume: default_volume(),
+                theme: default_theme(),
             },
             integrations: IntegrationSettings {
                 notifications_enabled: true,
@@ -148,5 +163,38 @@ mod tests {
         assert!(v["general"]["closeToTray"].is_boolean());
         assert!(v["general"]["backgroundPlayback"].is_boolean());
         assert!(v["integrations"]["notificationsEnabled"].is_boolean());
+    }
+
+    #[test]
+    fn default_theme_is_dark() {
+        let s = AppSettings::default();
+        assert_eq!(s.general.theme, ThemeMode::Dark);
+    }
+
+    #[test]
+    fn theme_roundtrips_via_json() {
+        let mut s = AppSettings::default();
+        s.general.theme = ThemeMode::System;
+        let bytes = serde_json::to_vec(&s).unwrap();
+        let parsed: AppSettings = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.general.theme, ThemeMode::System);
+    }
+
+    #[test]
+    fn theme_serializes_camel_case() {
+        let s = AppSettings::default();
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(v["general"]["theme"], "dark");
+    }
+
+    #[test]
+    fn missing_theme_field_defaults_to_dark() {
+        let json = r#"{
+            "general": { "closeToTray": true, "backgroundPlayback": true, "lastVolume": 0.5 },
+            "integrations": { "notificationsEnabled": true },
+            "shortcuts": { "playPause": "X", "nextTrack": "Y", "prevTrack": "Z" }
+        }"#;
+        let parsed: AppSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.general.theme, ThemeMode::Dark);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VibeYTM",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "identifier": "com.vibeytm.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tests/journeys.rs
+++ b/src-tauri/tests/journeys.rs
@@ -14,7 +14,7 @@ use vibeytm_lib::events::types::{AppEvent, PlaybackCommand};
 use vibeytm_lib::state::player::{
     AccountInfo, PlaybackStatus, PlayerState, RepeatMode, TrackInfo,
 };
-use vibeytm_lib::state::settings::{AppSettings, GeneralSettings, IntegrationSettings, ShortcutSettings};
+use vibeytm_lib::state::settings::{AppSettings, GeneralSettings, IntegrationSettings, ShortcutSettings, ThemeMode};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -191,6 +191,7 @@ fn settings_round_trip_with_modified_volume_and_toggles() {
             close_to_tray: false,
             background_playback: true,
             last_volume: 0.42,
+            theme: ThemeMode::Dark,
         },
         integrations: IntegrationSettings {
             notifications_enabled: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,13 @@ import { ShortcutCheatsheet } from './components/ShortcutCheatsheet';
 import { Toast } from './components/Toast';
 import { AddToPlaylistPicker } from './components/contextMenu/AddToPlaylistPicker';
 import { useBootState } from './hooks/useBootState';
+import { useTheme, type ThemeMode } from './hooks/useTheme';
 import { useGlobalShortcuts, type ShortcutBinding } from './hooks/useGlobalShortcuts';
 import { useTauriEvent } from './hooks/useTauriEvent';
-import { ytmApi, playerApi } from './lib/ipc';
+import { ytmApi, playerApi, settingsApi } from './lib/ipc';
 import { clearAllBrowseCaches } from './lib/persistentCache';
 import { subscribeToLibraryMutations } from './lib/libraryMutations';
+import { subscribeToThemeChange } from './lib/themeMutations';
 import { registerOpenArtist, registerOpenPlaylist } from './lib/appNav';
 import { OverlayStateContext } from './lib/overlayState';
 import type { FocusTimerState } from './components/player/FocusTimer/useFocusTimerCountdown';
@@ -38,6 +40,57 @@ const App: FC = () => {
   // pins down each transition.
   const { phase, isSplashDone, markHomeReady, markManualLogin } =
     useBootState();
+
+  // Theme — seeded from localStorage for instant paint, then overridden
+  // by the authoritative Rust settings on first load. SettingsPage
+  // notifies via `notifyThemeChanged()` when the user picks a new mode;
+  // App subscribes below so `useTheme` re-applies immediately.
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
+    if (typeof window === 'undefined') return 'dark';
+    try {
+      const stored = localStorage.getItem('vibeytm:theme-mode');
+      if (stored === 'dark' || stored === 'light' || stored === 'system') {
+        return stored;
+      }
+    } catch {
+      // localStorage unavailable — fall through to default.
+    }
+    return 'dark';
+  });
+  useTheme(themeMode);
+
+  // Load authoritative theme from Rust settings on mount.
+  useEffect(() => {
+    settingsApi
+      .get()
+      .then((s) => {
+        const t = s.general.theme;
+        if (t === 'dark' || t === 'light' || t === 'system') {
+          setThemeMode(t);
+          try {
+            localStorage.setItem('vibeytm:theme-mode', t);
+          } catch {
+            // non-fatal
+          }
+        }
+      })
+      .catch(() => {
+        // Settings load failed — keep localStorage seed.
+      });
+  }, []);
+
+  // Subscribe to theme changes from SettingsPage (or any future mutator).
+  useEffect(() => {
+    return subscribeToThemeChange((mode: ThemeMode) => {
+      setThemeMode(mode);
+      try {
+        localStorage.setItem('vibeytm:theme-mode', mode);
+      } catch {
+        // non-fatal
+      }
+    });
+  }, []);
+
   const [currentPath, setCurrentPath] = useState('home');
   const [isNowPlayingOpen, setIsNowPlayingOpen] = useState(false);
   const [isLyricsOpen, setIsLyricsOpen] = useState(false);

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { type FC, type ReactNode, useEffect, useRef, useState } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
 import { aboutApi, cacheApi, settingsApi, ytmApi, type AboutInfo, type AppSettings, type CacheStats } from '../../lib/ipc';
 import { debug } from '../../lib/debug';
+import { notifyThemeChanged } from '../../lib/themeMutations';
 
 declare const __APP_VERSION__: string;
 // Fallback only — the real version is fetched at runtime via Tauri's getVersion()
@@ -166,7 +167,7 @@ const Divider: FC = () => (
   <div
     style={{
       height: '1px',
-      background: 'oklch(100% 0 0 / 0.06)',
+      background: 'var(--glass-tile-bg)',
       margin: 'var(--space-1) 0',
     }}
   />
@@ -240,7 +241,7 @@ const SegmentedControl: FC<SegmentedControlProps> = ({ value, onChange, disabled
               background: isActive
                 ? 'var(--color-accent)'
                 : isHovered
-                  ? 'oklch(100% 0 0 / 0.06)'
+                  ? 'var(--glass-tile-bg)'
                   : 'transparent',
               color: isActive ? '#fff' : 'var(--color-text-secondary)',
             }}
@@ -392,7 +393,7 @@ export const SettingsPage: FC = () => {
           <SegmentedControl
             value={settings?.general.theme ?? 'dark'}
             disabled={!settings}
-            onChange={(v) => updateGeneral({ theme: v })}
+            onChange={(v) => { updateGeneral({ theme: v }); notifyThemeChanged(v); }}
           />
         </SettingRow>
       </SettingsCard>

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -190,6 +190,69 @@ const ShortcutBadge: FC<{ keys: string }> = ({ keys }) => (
   </span>
 );
 
+type ThemeOption = 'dark' | 'light' | 'system';
+
+interface SegmentedControlProps {
+  value: ThemeOption;
+  onChange: (value: ThemeOption) => void;
+  disabled?: boolean;
+}
+
+const THEME_OPTIONS: { value: ThemeOption; label: string }[] = [
+  { value: 'dark', label: 'Dark' },
+  { value: 'light', label: 'Light' },
+  { value: 'system', label: 'System' },
+];
+
+const SegmentedControl: FC<SegmentedControlProps> = ({ value, onChange, disabled = false }) => {
+  const [hovered, setHovered] = useState<ThemeOption | null>(null);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        background: 'var(--color-surface-3)',
+        borderRadius: 'var(--radius-sm)',
+        padding: '2px',
+        gap: '2px',
+      }}
+    >
+      {THEME_OPTIONS.map((option) => {
+        const isActive = value === option.value;
+        const isHovered = hovered === option.value && !isActive;
+        return (
+          <button
+            key={option.value}
+            onClick={() => {
+              if (!disabled) onChange(option.value);
+            }}
+            onMouseEnter={() => setHovered(option.value)}
+            onMouseLeave={() => setHovered(null)}
+            style={{
+              fontSize: 'var(--text-sm)',
+              fontWeight: 500,
+              padding: 'var(--space-1) var(--space-3)',
+              borderRadius: 'calc(var(--radius-sm) - 2px)',
+              border: 'none',
+              cursor: disabled ? 'not-allowed' : 'pointer',
+              opacity: disabled ? 0.4 : 1,
+              transition: `all var(--duration-fast) var(--ease-out)`,
+              background: isActive
+                ? 'var(--color-accent)'
+                : isHovered
+                  ? 'oklch(100% 0 0 / 0.06)'
+                  : 'transparent',
+              color: isActive ? '#fff' : 'var(--color-text-secondary)',
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
 const OutlinedButton: FC<{ label: string; onClick: () => void }> = ({ label, onClick }) => (
   <button
     onClick={onClick}
@@ -321,6 +384,18 @@ export const SettingsPage: FC = () => {
       >
         Settings
       </h1>
+
+      {/* Appearance */}
+      <SectionHeading title="Appearance" />
+      <SettingsCard>
+        <SettingRow label="Theme" description="Choose the app's color scheme">
+          <SegmentedControl
+            value={settings?.general.theme ?? 'dark'}
+            disabled={!settings}
+            onChange={(v) => updateGeneral({ theme: v })}
+          />
+        </SettingRow>
+      </SettingsCard>
 
       {/* General */}
       <SectionHeading title="General" />

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -12,12 +12,12 @@ describe('useTheme', () => {
 
     vi.spyOn(window, 'matchMedia').mockImplementation(() => ({
       matches: matchesValue,
-      addEventListener: (_event: string, handler: () => void) => {
-        listeners.push(handler);
-      },
-      removeEventListener: (_event: string, handler: () => void) => {
-        listeners = listeners.filter((l) => l !== handler);
-      },
+      addEventListener: vi.fn((_event: string, handler: EventListenerOrEventListenerObject) => {
+        listeners.push(handler as unknown as () => void);
+      }),
+      removeEventListener: vi.fn((_event: string, handler: EventListenerOrEventListenerObject) => {
+        listeners = listeners.filter((l) => l !== (handler as unknown as () => void));
+      }),
       media: '(prefers-color-scheme: dark)',
       onchange: null,
       addListener: vi.fn(),

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTheme } from './useTheme';
+
+describe('useTheme', () => {
+  let listeners: Array<() => void>;
+  let matchesValue: boolean;
+
+  beforeEach(() => {
+    listeners = [];
+    matchesValue = false;
+
+    vi.spyOn(window, 'matchMedia').mockImplementation(() => ({
+      matches: matchesValue,
+      addEventListener: (_event: string, handler: () => void) => {
+        listeners.push(handler);
+      },
+      removeEventListener: (_event: string, handler: () => void) => {
+        listeners = listeners.filter((l) => l !== handler);
+      },
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    vi.spyOn(document.documentElement, 'setAttribute');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets data-theme="dark" when mode is dark', () => {
+    renderHook(() => useTheme('dark'));
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
+  });
+
+  it('sets data-theme="light" when mode is light', () => {
+    renderHook(() => useTheme('light'));
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+  });
+
+  it('resolves system to dark when matchMedia matches', () => {
+    matchesValue = true;
+    renderHook(() => useTheme('system'));
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
+  });
+
+  it('resolves system to light when matchMedia does not match', () => {
+    matchesValue = false;
+    renderHook(() => useTheme('system'));
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+  });
+
+  it('listens to matchMedia changes and updates data-theme', () => {
+    matchesValue = false;
+    renderHook(() => useTheme('system'));
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+
+    // Simulate system preference changing to dark
+    matchesValue = true;
+    listeners.forEach((l) => l());
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
+  });
+
+  it('writes resolved theme to localStorage', () => {
+    // jsdom's localStorage is a custom object; spy on it directly via
+    // Object.defineProperty so we can observe the setItem call.
+    const calls: Array<[string, string]> = [];
+    const original = window.localStorage;
+    const store: Record<string, string> = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => { store[k] = v; calls.push([k, v]); },
+        removeItem: (k: string) => { delete store[k]; },
+      },
+    });
+    renderHook(() => useTheme('dark'));
+    expect(calls).toContainEqual(['vibeytm:theme', 'dark']);
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: original });
+  });
+
+  it('cleans up matchMedia listener on unmount', () => {
+    const { unmount } = renderHook(() => useTheme('system'));
+    expect(listeners.length).toBe(1);
+    unmount();
+    expect(listeners.length).toBe(0);
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+
+export type ThemeMode = 'dark' | 'light' | 'system';
+
+const STORAGE_KEY = 'vibeytm:theme';
+
+function resolveTheme(mode: ThemeMode): 'dark' | 'light' {
+  if (mode === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  }
+  return mode;
+}
+
+function applyTheme(resolved: 'dark' | 'light') {
+  document.documentElement.setAttribute('data-theme', resolved);
+  try {
+    localStorage.setItem(STORAGE_KEY, resolved);
+  } catch {
+    // localStorage unavailable — no persistence this session.
+  }
+}
+
+export function useTheme(mode: ThemeMode): void {
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+
+  useEffect(() => {
+    applyTheme(resolveTheme(mode));
+
+    if (mode !== 'system') return;
+
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      if (modeRef.current === 'system') {
+        applyTheme(resolveTheme('system'));
+      }
+    };
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [mode]);
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -28,6 +28,7 @@ export function useTheme(mode: ThemeMode): void {
 
   useEffect(() => {
     applyTheme(resolveTheme(mode));
+    try { localStorage.setItem('vibeytm:theme-mode', mode); } catch { /* */ }
 
     if (mode !== 'system') return;
 

--- a/src/lib/coverColors.ts
+++ b/src/lib/coverColors.ts
@@ -33,10 +33,23 @@ const NEAR_BLACK_THRESHOLD = 28;
 const NEAR_WHITE_THRESHOLD = 232;
 const ALPHA_OPAQUE_THRESHOLD = 200;
 
-const FALLBACK: CoverColors = {
+const FALLBACK_DARK: CoverColors = {
   primary: 'oklch(22% 0.04 270)',
   secondary: 'oklch(14% 0.02 270)',
 };
+
+const FALLBACK_LIGHT: CoverColors = {
+  primary: 'oklch(90% 0.02 270)',
+  secondary: 'oklch(85% 0.04 270)',
+};
+
+function getFallback(): CoverColors {
+  if (typeof document !== 'undefined') {
+    const theme = document.documentElement.dataset.theme;
+    if (theme === 'light') return FALLBACK_LIGHT;
+  }
+  return FALLBACK_DARK;
+}
 
 interface BucketHit {
   /** Quantized 12-bit key (4 bits per RGB channel). */
@@ -49,7 +62,7 @@ interface BucketHit {
 
 /** Pull the dominant + secondary color out of a cover. Memoized per URL. */
 export async function extractCoverColors(url: string): Promise<CoverColors> {
-  if (!url) return FALLBACK;
+  if (!url) return getFallback();
   const hit = cache.get(url);
   if (hit) return hit;
   const pending = inflight.get(url);
@@ -61,8 +74,9 @@ export async function extractCoverColors(url: string): Promise<CoverColors> {
       cache.set(url, colors);
       return colors;
     } catch {
-      cache.set(url, FALLBACK);
-      return FALLBACK;
+      const fb = getFallback();
+      cache.set(url, fb);
+      return fb;
     } finally {
       inflight.delete(url);
     }
@@ -131,7 +145,7 @@ export function pickPalette(data: Uint8ClampedArray): CoverColors {
     }
   }
 
-  if (buckets.size === 0) return FALLBACK;
+  if (buckets.size === 0) return getFallback();
 
   const sorted = [...buckets.values()].sort((a, b) => b.count - a.count);
   const primaryHit = sorted[0];

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -234,6 +234,7 @@ export interface AppSettings {
      * `set_settings` without losing the volume.
      */
     lastVolume: number;
+    theme: 'dark' | 'light' | 'system';
   };
   integrations: {
     notificationsEnabled: boolean;

--- a/src/lib/themeMutations.ts
+++ b/src/lib/themeMutations.ts
@@ -1,0 +1,32 @@
+// Theme-change pub/sub.
+//
+// When SettingsPage (or any future surface) changes the theme mode,
+// the mutator calls `notifyThemeChanged(mode)`. `App.tsx` subscribes
+// via `subscribeToThemeChange(...)` and updates its `themeMode` state
+// so `useTheme` re-applies the `data-theme` attribute immediately.
+//
+// Mirrors the `libraryMutations.ts` pattern — deliberately tiny, no
+// React deps, no framework coupling.
+
+import type { ThemeMode } from '../hooks/useTheme';
+
+type ThemeListener = (mode: ThemeMode) => void;
+
+const listeners = new Set<ThemeListener>();
+
+export function notifyThemeChanged(mode: ThemeMode): void {
+  for (const listener of listeners) {
+    try {
+      listener(mode);
+    } catch {
+      // Listener threw — swallow so the remaining listeners still fire.
+    }
+  }
+}
+
+export function subscribeToThemeChange(listener: ThemeListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -87,6 +87,10 @@ class RootErrorBoundary extends React.Component<
             flexDirection: 'column',
             gap: '1rem',
             padding: '2rem',
+            // Hardcoded dark background + light text — intentional.
+            // This error boundary renders when the React tree (and
+            // therefore CSS custom-property injection) may be broken,
+            // so we cannot rely on design tokens from tokens.css.
             background: 'oklch(12% 0.005 270)',
             color: 'oklch(85% 0 0)',
             fontFamily:
@@ -118,6 +122,7 @@ class RootErrorBoundary extends React.Component<
             style={{
               marginTop: '0.5rem',
               padding: '0.6rem 1.4rem',
+              // Hardcoded accent — intentional (see comment above).
               background: 'oklch(63% 0.258 29)',
               color: 'white',
               border: 'none',

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -147,3 +147,51 @@
   --duration-slow: 400ms;
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
+
+/* ─── Light theme overrides ─────────────────────────────────────────
+   Applied when `data-theme="light"` is set on the root element.
+   Only color tokens are overridden — typography, spacing, layout,
+   radius, motion, and --glass-recipe are inherited from :root.
+   --color-accent (YouTube red) is unchanged. */
+[data-theme="light"] {
+  /* Surfaces — high lightness, faint blue-gray tint */
+  --color-bg: oklch(97% 0.005 270);
+  --color-surface-1: oklch(94% 0.005 270);
+  --color-surface-2: oklch(91% 0.005 270);
+  --color-surface-3: oklch(88% 0.005 270);
+
+  /* Text — dark on light */
+  --color-text-primary: oklch(15% 0 0);
+  --color-text-secondary: oklch(35% 0 0);
+  --color-text-tertiary: oklch(50% 0 0);
+
+  /* Glass backgrounds — light-tinted translucent whites */
+  --glass-bg-chrome: oklch(100% 0.005 270 / 0.55);
+  --glass-bg-card: oklch(100% 0.005 270 / 0.45);
+
+  /* Glass rims — inverted: dark rims on light surfaces */
+  --glass-rim-bright: oklch(0% 0 0 / 0.15);
+  --glass-rim-mid: oklch(0% 0 0 / 0.10);
+  --glass-rim-dim: oklch(0% 0 0 / 0.06);
+
+  /* Glass shadows — lighter drop shadows for light mode */
+  --glass-plate-shadow: inset 0 1px 0 var(--glass-rim-bright),
+    0 24px 60px oklch(0% 0 0 / 0.18);
+  --glass-card-shadow: inset 0 1px 0 var(--glass-rim-bright),
+    0 2px 12px oklch(0% 0 0 / 0.08);
+
+  /* Glass tiles — dark tint on light background */
+  --glass-tile-bg: oklch(0% 0 0 / 0.06);
+  --glass-tile-bg-active: oklch(0% 0 0 / 0.10);
+  --glass-tile-shadow:
+    inset 0 1px 0 var(--glass-rim-bright),
+    inset 0 -1px 0 oklch(0% 0 0 / 0.05),
+    0 2px 6px oklch(0% 0 0 / 0.10);
+  --glass-tile-shadow-rest:
+    inset 0 1px 0 var(--glass-rim-mid),
+    0 1px 3px oklch(0% 0 0 / 0.08);
+
+  /* Ambient tints — higher lightness for light background */
+  --ambient-tint-1: oklch(88% 0.06 280);
+  --ambient-tint-2: oklch(86% 0.08 25);
+}


### PR DESCRIPTION
Add theme support to VibeYTM so users can switch between Dark (current default), Light, and System-preference-following appearance modes. The app currently uses a single dark theme defined via CSS custom properties in `src/styles/tokens.css`. This feature introduces a light variant of those tokens, a theme preference persisted in the existing `AppSettings` (Rust-backed, JSON on disk), and a UI toggle in SettingsPage. Since the token system already centralizes all color decisions via `--color-*` and `--glass-*` variables, the visual switchover only requires swapping the `:root` variable block — no inline color literals should need changing.